### PR TITLE
fix(docker): prevent nft NAT fallback from hanging

### DIFF
--- a/roles/docker/tasks/redhat_nat_fallback.yml
+++ b/roles/docker/tasks/redhat_nat_fallback.yml
@@ -50,6 +50,27 @@
   changed_when: false
   failed_when: false
 
+- name: Compute NAT fallback subnet list
+  ansible.builtin.set_fact:
+    docker_nat_fallback_subnets: >-
+      {{
+        (
+          (_docker_nat_subnets.stdout_lines | default([]))
+          | map('trim')
+          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+$')
+          | list
+          | unique
+        )
+        if (
+          (_docker_nat_subnets.stdout_lines | default([]))
+          | map('trim')
+          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+$')
+          | list
+          | length
+        ) > 0
+        else ['172.16.0.0/12']
+      }}
+
 - name: Apply Docker bridge egress NAT (nftables masquerade)
   ansible.builtin.shell:
     cmd: |
@@ -61,21 +82,33 @@
         echo "nft not found; install nftables" >&2
         exit 1
       fi
-      nft delete table ip ansible_docker_nat 2>/dev/null || true
-      nft add table ip ansible_docker_nat
-      nft add chain ip ansible_docker_nat postrouting '{ type nat hook postrouting priority 100; policy accept; }'
-      buf=$(cat || true)
-      if [ -z "${buf//[$'\t\r\n ']}" ]; then
-        buf=$'172.16.0.0/12'
-      fi
-      printf '%s\n' "$buf" | sort -u | while IFS= read -r raw; do
-        cidr="${raw//[$'\t\r\n ']}"
-        [ -z "$cidr" ] && continue
-        [[ "$cidr" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]] || continue
-        nft add rule ip ansible_docker_nat postrouting ip saddr "$cidr" ip daddr != "$cidr" masquerade
-      done
+      timeout 10s nft delete table ip ansible_docker_nat 2>/dev/null || true
+      timeout 10s nft add table ip ansible_docker_nat
+      timeout 10s nft add chain ip ansible_docker_nat postrouting '{ type nat hook postrouting priority 100; policy accept; }'
       echo CHANGED
     executable: /bin/bash
-    stdin: "{{ _docker_nat_subnets.stdout | default('') }}"
   register: _docker_nat_nft
   changed_when: "'CHANGED' in (_docker_nat_nft.stdout | default(''))"
+
+- name: Add nftables masquerade rules per Docker subnet
+  ansible.builtin.command:
+    argv:
+      - timeout
+      - "10s"
+      - nft
+      - add
+      - rule
+      - ip
+      - ansible_docker_nat
+      - postrouting
+      - ip
+      - saddr
+      - "{{ item }}"
+      - ip
+      - daddr
+      - "!="
+      - "{{ item }}"
+      - masquerade
+  register: _docker_nat_rules
+  changed_when: true
+  loop: "{{ docker_nat_fallback_subnets }}"


### PR DESCRIPTION
## Summary
Single, clean change on current `dev`: the Docker EL bridge NAT fallback no longer uses `cat`/stdin (which could block) and applies `nft` with explicit CIDRs and `timeout`.

## Test plan
- Molecule / Rocky Vagrant converge past `docker` NAT tasks

Made with [Cursor](https://cursor.com)