### PR TITLE
Add architecture-aware Unbound and Nebula Sync verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ cython_debug/
 roles/pihole
 .ansible
 inventory/inventory.yaml
+inventory/rnet.yml

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Roles include (among others):
 - [`bootstrap`](roles/bootstrap/tasks/main.yml): SSH key from GitHub (`github_user_for_ssh_key`), optional password lock, aliases, timezone, hostname, packages such as firewalld on Debian/Ubuntu.
 - [`updates`](roles/updates/tasks/main.yml), [`sshd`](roles/sshd/tasks/main.yml), [`docker`](roles/docker/tasks/main.yml), [`unbound`](roles/unbound/tasks/main.yml), [`pihole`](roles/pihole/tasks/main.yml) (often from Galaxy; see [`roles/requirements.yml`](roles/requirements.yml)), [`keepalived`](roles/keepalived/tasks/main.yml), [`start_keepalived`](roles/start_keepalived/tasks/main.yml) / [`stop_keepalived`](roles/stop_keepalived/tasks/main.yml) as used in the play.
 
+On RedHat/Rocky hosts the Docker role installs `kernel-modules-extra` by default for Docker/netfilter support. If a real host already has the needed modules and `/boot` is too tight for kernel package changes, opt out in inventory:
+
+```yaml
+docker_install_kernel_modules_extra: false
+```
+
 Pi-hole-related variables (e.g. `pihole_environment_variables`, `pihole_ha_mode`, `pihole_vip_ipv4` / `pihole_vip_ipv6`) are typically set in inventory; see the [docker-pi-hole environment docs](https://github.com/pi-hole/docker-pi-hole#environment-variables) for image variables.
 
 Unbound is deployed before Pi-hole and can be used as Pi-hole's upstream resolver over a shared Docker network. By default the Unbound role now chooses an image from `unbound_image_arch_map` using the target host architecture:

--- a/inventory/vagrant.yml
+++ b/inventory/vagrant.yml
@@ -32,8 +32,7 @@ all:
     pihole_webport_http: '80'  # Port for HTTP-Requests to Webinterface.
     pihole_webport_https: '443'  # Port for HTTPS-DoH Requests.
     pihole_firewall_deploy: false  # will ensure firewalld is install and configured
-    # Rocky/Vagrant debug: bypass Docker bridge and publish directly on host namespace
-    pihole_use_host_network: true
+    pihole_use_host_network: false
     DHCP_ACTIVE: false
     pihole_environment_variables:
       TZ: "{{ timezone }}"
@@ -44,8 +43,7 @@ all:
       REV_SERVER: false
       REV_SERVER_CIDR: "192.168.56.0/24"
       REV_SERVER_TARGET: "192.168.56.1"
-      PIHOLE_DNS_: "1.1.1.1;8.8.8.8"
-      DNSMASQ_LISTENING: "all"
+      FTLCONF_dns_upstreams: "{{ pihole_unbound_upstream }}"
     pihole_ha_mode: true
     pihole_vip_ipv4: "192.168.56.10/24"
     pihole_vip_ipv6: "fd00::10/64"
@@ -62,7 +60,7 @@ all:
     nebula_sync_full_sync: true
     nebula_sync_cron: "*/15 * * * *"
     nebula_sync_dir: "/opt/nebula"
-    pihole_upstream_dns: "{{ unbound_container_name }}#{{ unbound_port }}"
+    pihole_unbound_upstream: "{{ unbound_container_name }}#{{ unbound_port }}"
     pihole_network_name: "{{ unbound_network_name }}"
     pihole_network_external: true
     pihole_rocky_network_debug: true

--- a/inventory/vagrant_libvirt.yml
+++ b/inventory/vagrant_libvirt.yml
@@ -37,6 +37,7 @@ all:
       REV_SERVER: false
       REV_SERVER_CIDR: "192.168.121.0/24"
       REV_SERVER_TARGET: "192.168.121.1"
+      FTLCONF_dns_upstreams: "{{ pihole_unbound_upstream }}"
     pihole_ha_mode: true
     pihole_vip_ipv4: "192.168.121.10/24"
     pihole_vip_ipv6: "fd00::10/64"
@@ -53,6 +54,6 @@ all:
     nebula_sync_full_sync: true
     nebula_sync_cron: "*/15 * * * *"
     nebula_sync_dir: "/opt/nebula"
-    pihole_upstream_dns: "{{ unbound_container_name }}#{{ unbound_port }}"
+    pihole_unbound_upstream: "{{ unbound_container_name }}#{{ unbound_port }}"
     pihole_network_name: "{{ unbound_network_name }}"
     pihole_network_external: true

--- a/molecule/common/verify_ha.yml
+++ b/molecule/common/verify_ha.yml
@@ -145,6 +145,47 @@
         fail_msg: "VIP DNS did not return a valid IPv4."
       run_once: true
 
+    # --- Nebula Sync ---
+    - name: Check Nebula Sync container
+      community.docker.docker_container_info:
+        name: "{{ nebula_sync_container_name | default('nebula') }}"
+      register: nebula_sync_container_info
+      when: nebula_sync_primary_url is defined
+
+    - name: Assert Nebula Sync container is running
+      ansible.builtin.assert:
+        that:
+          - nebula_sync_container_info.exists | default(false)
+          - nebula_sync_container_info.container.State.Running | default(false)
+        fail_msg: "Nebula Sync container is not running."
+      when: nebula_sync_primary_url is defined
+
+    - name: Set Docker inspect environment format
+      ansible.builtin.set_fact:
+        docker_inspect_env_fmt: "{{ '{{range .Config.Env}}{{println .}}{{end}}' }}"
+      when: nebula_sync_primary_url is defined
+
+    - name: Read Nebula Sync container environment
+      ansible.builtin.command:
+        argv:
+          - docker
+          - inspect
+          - --format
+          - "{{ docker_inspect_env_fmt }}"
+          - "{{ nebula_sync_container_name | default('nebula') }}"
+      register: nebula_sync_env
+      changed_when: false
+      when: nebula_sync_primary_url is defined
+
+    - name: Assert Nebula Sync points at expected Pi-hole instances
+      ansible.builtin.assert:
+        that:
+          - ('PRIMARY=' ~ nebula_sync_primary_url ~ '|' ~ nebula_sync_primary_password) in nebula_sync_env.stdout_lines
+          - nebula_sync_replicas | length > 0
+          - nebula_sync_env.stdout_lines | select('search', '^REPLICAS=.*' ~ nebula_sync_replicas[0].url) | list | length > 0
+        fail_msg: "Nebula Sync PRIMARY/REPLICAS environment does not match inventory."
+      when: nebula_sync_primary_url is defined
+
     # --- Docker container stop triggers VIP move ---
     - name: Check HA container on primary before docker failover test
       community.docker.docker_container_info:

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -6,6 +6,11 @@ docker_disable_ipv6: true
 # Extra repo connectivity diagnostics are off by default (only used when debugging).
 docker_repo_diagnostics: false
 
+# Install kernel-modules-extra on RedHat/Rocky so Docker/netfilter modules are
+# available. Set false on hosts where the modules already exist or /boot cannot
+# accommodate kernel package churn.
+docker_install_kernel_modules_extra: true
+
 # Whether Docker should manage iptables rules itself. In some VM kernels
 # (e.g. VirtualBox guests) required xtables matches may be unavailable.
 docker_manage_iptables: "{{ not (vagrant_env | default(false) | bool) }}"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -222,7 +222,9 @@
       - kernel-modules-extra
     state: present
     lock_timeout: 300
-  when: ansible_facts['os_family'] == 'RedHat'
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - docker_install_kernel_modules_extra | default(true) | bool
 
 - name: Load required kernel modules for Docker networking (RedHat family)
   ansible.builtin.command: "modprobe {{ item }}"

--- a/roles/nebula_sync/templates/docker-compose.yml.j2
+++ b/roles/nebula_sync/templates/docker-compose.yml.j2
@@ -3,6 +3,10 @@ services:
     image: "{{ nebula_sync_image }}:{{ nebula_sync_image_tag }}"
     container_name: "{{ nebula_sync_container_name }}"
     restart: unless-stopped
+{% if nebula_sync_use_env_file | bool %}
+    env_file:
+      - "{{ nebula_sync_env_filename }}"
+{% else %}
     environment:
       TZ: "{{ nebula_sync_tz }}"
       PRIMARY: "{{ nebula_sync_primary_url }}|{{ nebula_sync_primary_password }}"
@@ -10,3 +14,22 @@ services:
       FULL_SYNC: "{{ nebula_sync_full_sync | string | lower }}"
       RUN_GRAVITY: "{{ nebula_sync_run_gravity | string | lower }}"
       CRON: "{{ nebula_sync_cron }}"
+      CLIENT_SKIP_TLS_VERIFICATION: "{{ nebula_sync_client_skip_tls_verification | string | lower }}"
+      CLIENT_RETRY_DELAY_SECONDS: "{{ nebula_sync_client_retry_delay_seconds }}"
+      CLIENT_TIMEOUT_SECONDS: "{{ nebula_sync_client_timeout_seconds }}"
+      SYNC_CONFIG_DNS: "{{ nebula_sync_sync_config.dns | string | lower }}"
+      SYNC_CONFIG_DHCP: "{{ nebula_sync_sync_config.dhcp | string | lower }}"
+      SYNC_CONFIG_NTP: "{{ nebula_sync_sync_config.ntp | string | lower }}"
+      SYNC_CONFIG_RESOLVER: "{{ nebula_sync_sync_config.resolver | string | lower }}"
+      SYNC_CONFIG_DATABASE: "{{ nebula_sync_sync_config.database | string | lower }}"
+      SYNC_CONFIG_MISC: "{{ nebula_sync_sync_config.misc | string | lower }}"
+      SYNC_CONFIG_DEBUG: "{{ nebula_sync_sync_config.debug | string | lower }}"
+      SYNC_GRAVITY_DHCP_LEASES: "{{ nebula_sync_sync_gravity.dhcp_leases | string | lower }}"
+      SYNC_GRAVITY_GROUP: "{{ nebula_sync_sync_gravity.group | string | lower }}"
+      SYNC_GRAVITY_AD_LIST: "{{ nebula_sync_sync_gravity.ad_list | string | lower }}"
+      SYNC_GRAVITY_AD_LIST_BY_GROUP: "{{ nebula_sync_sync_gravity.ad_list_by_group | string | lower }}"
+      SYNC_GRAVITY_DOMAIN_LIST: "{{ nebula_sync_sync_gravity.domain_list | string | lower }}"
+      SYNC_GRAVITY_DOMAIN_LIST_BY_GROUP: "{{ nebula_sync_sync_gravity.domain_list_by_group | string | lower }}"
+      SYNC_GRAVITY_CLIENT: "{{ nebula_sync_sync_gravity.client | string | lower }}"
+      SYNC_GRAVITY_CLIENT_BY_GROUP: "{{ nebula_sync_sync_gravity.client_by_group | string | lower }}"
+{% endif %}


### PR DESCRIPTION
## Summary
- select Unbound image by target architecture, with inventory override support
- allow RedHat/Rocky hosts to skip kernel-modules-extra installs when /boot is constrained
- align Vagrant inventories with Pi-hole v6 Unbound upstream variables
- wire Nebula Sync env_file correctly and verify the Nebula Sync container/env in Molecule
- fix Unbound root.hints bind mount and verify Unbound over Docker-network IP

## Verification
- ansible-playbook -i inventory/rnet.yml playbooks/bootstrap-pihole.yaml --syntax-check
- ansible-playbook -i inventory/ci/ci.yml playbooks/sync.yaml --syntax-check
- ansible-playbook -i inventory/vagrant.yml playbooks/bootstrap-pihole.yaml --syntax-check
- ansible-playbook -i inventory/vagrant_libvirt.yml playbooks/bootstrap-pihole.yaml --syntax-check
- ansible-playbook -i inventory/vagrant.yml molecule/default/verify.yml --syntax-check
- ansible-playbook -i inventory/rnet.yml playbooks/bootstrap-pihole.yaml --tags unbound