### PR TITLE
Fix nebula-sync env rendering

### DIFF
--- a/roles/nebula_sync/templates/docker-compose.yml.j2
+++ b/roles/nebula_sync/templates/docker-compose.yml.j2
@@ -6,11 +6,13 @@ services:
 {% if nebula_sync_use_env_file | bool %}
     env_file:
       - "{{ nebula_sync_env_filename }}"
-{% else %}
+{% endif %}
     environment:
+{% if not (nebula_sync_use_env_file | bool) %}
       TZ: "{{ nebula_sync_tz }}"
       PRIMARY: "{{ nebula_sync_primary_url }}|{{ nebula_sync_primary_password }}"
       REPLICAS: "{% for r in nebula_sync_replicas %}{{ r.url }}|{{ r.password }}{% if not loop.last %},{% endif %}{% endfor %}"
+{% endif %}
       FULL_SYNC: "{{ nebula_sync_full_sync | string | lower }}"
       RUN_GRAVITY: "{{ nebula_sync_run_gravity | string | lower }}"
       CRON: "{{ nebula_sync_cron }}"
@@ -32,4 +34,3 @@ services:
       SYNC_GRAVITY_DOMAIN_LIST_BY_GROUP: "{{ nebula_sync_sync_gravity.domain_list_by_group | string | lower }}"
       SYNC_GRAVITY_CLIENT: "{{ nebula_sync_sync_gravity.client | string | lower }}"
       SYNC_GRAVITY_CLIENT_BY_GROUP: "{{ nebula_sync_sync_gravity.client_by_group | string | lower }}"
-{% endif %}

--- a/roles/nebula_sync/templates/env.j2
+++ b/roles/nebula_sync/templates/env.j2
@@ -1,29 +1,29 @@
 TZ={{ nebula_sync_tz }}
 
 PRIMARY={{ nebula_sync_primary_url }}|{{ nebula_sync_primary_password }}
-REPLICAS={%- for r in nebula_sync_replicas -%}{{ r.url }}|{{ r.password }}{% if not loop.last %},{% endif %}{%- endfor -%}
+REPLICAS={% for r in nebula_sync_replicas %}{{ r.url }}|{{ r.password }}{% if not loop.last %},{% endif %}{% endfor %}
 
-FULL_SYNC={{ nebula_sync_full_sync | lower }}
-RUN_GRAVITY={{ nebula_sync_run_gravity | lower }}
+FULL_SYNC={{ nebula_sync_full_sync | string | lower }}
+RUN_GRAVITY={{ nebula_sync_run_gravity | string | lower }}
 CRON={{ nebula_sync_cron }}
 
-CLIENT_SKIP_TLS_VERIFICATION={{ nebula_sync_client_skip_tls_verification | lower }}
+CLIENT_SKIP_TLS_VERIFICATION={{ nebula_sync_client_skip_tls_verification | string | lower }}
 CLIENT_RETRY_DELAY_SECONDS={{ nebula_sync_client_retry_delay_seconds }}
 CLIENT_TIMEOUT_SECONDS={{ nebula_sync_client_timeout_seconds }}
 
-SYNC_CONFIG_DNS={{ nebula_sync_sync_config.dns | lower }}
-SYNC_CONFIG_DHCP={{ nebula_sync_sync_config.dhcp | lower }}
-SYNC_CONFIG_NTP={{ nebula_sync_sync_config.ntp | lower }}
-SYNC_CONFIG_RESOLVER={{ nebula_sync_sync_config.resolver | lower }}
-SYNC_CONFIG_DATABASE={{ nebula_sync_sync_config.database | lower }}
-SYNC_CONFIG_MISC={{ nebula_sync_sync_config.misc | lower }}
-SYNC_CONFIG_DEBUG={{ nebula_sync_sync_config.debug | lower }}
+SYNC_CONFIG_DNS={{ nebula_sync_sync_config.dns | string | lower }}
+SYNC_CONFIG_DHCP={{ nebula_sync_sync_config.dhcp | string | lower }}
+SYNC_CONFIG_NTP={{ nebula_sync_sync_config.ntp | string | lower }}
+SYNC_CONFIG_RESOLVER={{ nebula_sync_sync_config.resolver | string | lower }}
+SYNC_CONFIG_DATABASE={{ nebula_sync_sync_config.database | string | lower }}
+SYNC_CONFIG_MISC={{ nebula_sync_sync_config.misc | string | lower }}
+SYNC_CONFIG_DEBUG={{ nebula_sync_sync_config.debug | string | lower }}
 
-SYNC_GRAVITY_DHCP_LEASES={{ nebula_sync_sync_gravity.dhcp_leases | lower }}
-SYNC_GRAVITY_GROUP={{ nebula_sync_sync_gravity.group | lower }}
-SYNC_GRAVITY_AD_LIST={{ nebula_sync_sync_gravity.ad_list | lower }}
-SYNC_GRAVITY_AD_LIST_BY_GROUP={{ nebula_sync_sync_gravity.ad_list_by_group | lower }}
-SYNC_GRAVITY_DOMAIN_LIST={{ nebula_sync_sync_gravity.domain_list | lower }}
-SYNC_GRAVITY_DOMAIN_LIST_BY_GROUP={{ nebula_sync_sync_gravity.domain_list_by_group | lower }}
-SYNC_GRAVITY_CLIENT={{ nebula_sync_sync_gravity.client | lower }}
-SYNC_GRAVITY_CLIENT_BY_GROUP={{ nebula_sync_sync_gravity.client_by_group | lower }}
+SYNC_GRAVITY_DHCP_LEASES={{ nebula_sync_sync_gravity.dhcp_leases | string | lower }}
+SYNC_GRAVITY_GROUP={{ nebula_sync_sync_gravity.group | string | lower }}
+SYNC_GRAVITY_AD_LIST={{ nebula_sync_sync_gravity.ad_list | string | lower }}
+SYNC_GRAVITY_AD_LIST_BY_GROUP={{ nebula_sync_sync_gravity.ad_list_by_group | string | lower }}
+SYNC_GRAVITY_DOMAIN_LIST={{ nebula_sync_sync_gravity.domain_list | string | lower }}
+SYNC_GRAVITY_DOMAIN_LIST_BY_GROUP={{ nebula_sync_sync_gravity.domain_list_by_group | string | lower }}
+SYNC_GRAVITY_CLIENT={{ nebula_sync_sync_gravity.client | string | lower }}
+SYNC_GRAVITY_CLIENT_BY_GROUP={{ nebula_sync_sync_gravity.client_by_group | string | lower }}


### PR DESCRIPTION
## Summary
- keep REPLICAS on its own .env line so FULL_SYNC is not appended to the replica password
- render Nebula boolean values explicitly as lowercase strings
- expose non-secret sync flags in compose even when secrets are loaded from .env

## Testing
- ANSIBLE_HOME=/tmp/ansible-pihole-home ANSIBLE_LOCAL_TEMP=/tmp/ansible-pihole-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-pihole-remote ANSIBLE_SSH_CONTROL_PATH_DIR=/tmp/ansible-pihole-cp ansible-playbook -i inventory/rnet.yml playbooks/sync.yaml --syntax-check
- Applied to pihole-01 and verified Nebula logs show Sync completed