### PR TITLE
Fix ansible.posix collection install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For the upstream Pi-hole container image, see: https://github.com/pi-hole/docker
 ./scripts/install-ansible-collections.sh
 ```
 
-This installs Galaxy **roles** ([`roles/requirements.yml`](roles/requirements.yml)), **`ansible.posix` from git** (branch with the ansible-core 2.24-safe imports from [ansible.posix PR #690](https://github.com/ansible-collections/ansible.posix/pull/690) until a Galaxy release includes it), then **collections** listed in [`collections/requirements.yml`](collections/requirements.yml). **Git** is required for that `ansible.posix` step.
+This installs Galaxy **roles** ([`roles/requirements.yml`](roles/requirements.yml)), **`ansible.posix` from git** (the merged commit from [ansible.posix PR #690](https://github.com/ansible-collections/ansible.posix/pull/690) with ansible-core 2.24-safe imports until a Galaxy release includes it), then **collections** listed in [`collections/requirements.yml`](collections/requirements.yml). **Git** is required for that `ansible.posix` step.
 
 Ansible uses [`ansible.cfg`](ansible.cfg) (`roles_path`, `collections_path`). Re-run the script after changing dependency files.
 

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,7 +1,7 @@
 ---
 # Galaxy-only collections (semver). ansible.posix is installed separately — see
 # scripts/install-ansible-collections.sh (git install avoids resolver bugs with git SHAs in YAML).
-# When https://github.com/ansible-collections/ansible.posix/pull/690 is released, add:
+# When the fix from https://github.com/ansible-collections/ansible.posix/pull/690 is released, add:
 #   - name: ansible.posix
 #     version: ">=2.2.0"
 # and remove the git step from the script.

--- a/scripts/install-ansible-collections.sh
+++ b/scripts/install-ansible-collections.sh
@@ -14,9 +14,9 @@ if [[ -f "$ROOT/roles/requirements.yml" ]]; then
   ansible-galaxy role install -r "$ROOT/roles/requirements.yml" -p "$ROOT/roles"
 fi
 
-# Pinned branch: https://github.com/ansible-collections/ansible.posix/pull/690
+# Pinned merge commit from https://github.com/ansible-collections/ansible.posix/pull/690
 ansible-galaxy collection install \
-  git+https://github.com/barpavel/ansible.posix.git,fix-686-module-utils-deprecation \
+  git+https://github.com/ansible-collections/ansible.posix.git,2022c1bd86e42d8f8f682caa1c7fffd301f80ab9 \
   -p "$COL" \
   --force
 


### PR DESCRIPTION
## Summary
- install ansible.posix from the upstream merged PR #690 commit instead of the deleted fork branch
- update dependency comments and README wording to match the stable pinned ref

## Validation
- ran `bash -n scripts/install-ansible-collections.sh`
- ran `ANSIBLE_HOME=/tmp/ansible-pihole-home ANSIBLE_LOCAL_TEMP=/tmp/ansible-pihole-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-pihole-remote ./scripts/install-ansible-collections.sh`
- refreshed PR #47 checks after the fix; Ansible/YAML lint and syntax dry-run passed