### PR TITLE
Add nebula-sync secret file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Deploy or adjust keepalived HA between Pi-hole instances. Priorities and VIPs ar
 
 Deploy [Nebula Sync](https://github.com/lovelaze/nebula-sync) via [`roles/nebula_sync`](roles/nebula_sync/tasks/main.yml). Override `nebula_sync_image_tag` in inventory if you do not want `latest`.
 
+Set `nebula_sync_use_secret_files: true` to write the Nebula Sync `PRIMARY` and `REPLICAS` values to rootless-readable files and mount them into the container as `PRIMARY_FILE` / `REPLICAS_FILE`. The role defaults ownership to UID/GID `1001`, matching the upstream container user.
+
 ### Playbook tags
 
 Roles are tagged (e.g. `pihole`, `docker`, `unbound`, `ha`, `stopkeepalived`, `startkeepalived`; `sync.yaml` uses `nebulasync`, `nebula`, `sync`). Limit execution, for example:

--- a/roles/nebula_sync/defaults/main.yml
+++ b/roles/nebula_sync/defaults/main.yml
@@ -47,3 +47,13 @@ nebula_sync_sync_gravity:
 # Whether to render a .env file instead of embedding env in compose
 nebula_sync_use_env_file: true
 nebula_sync_env_filename: ".env"
+
+# Store PRIMARY/REPLICAS credentials in read-only files mounted into the container.
+# Nebula Sync runs as UID/GID 1001 by default, so the files must be readable by 1001.
+nebula_sync_use_secret_files: false
+nebula_sync_secret_dir: "{{ nebula_sync_dir }}/secrets"
+nebula_sync_secret_container_dir: "/run/secrets"
+nebula_sync_secret_file_owner: "1001"
+nebula_sync_secret_file_group: "1001"
+nebula_sync_primary_secret_filename: "primary"
+nebula_sync_replicas_secret_filename: "replicas"

--- a/roles/nebula_sync/tasks/main.yml
+++ b/roles/nebula_sync/tasks/main.yml
@@ -7,6 +7,38 @@
     group: "{{ ansible_user }}"
     mode: '0755'
 
+- name: Ensure nebula-sync secrets directory exists
+  when: nebula_sync_use_secret_files | bool
+  ansible.builtin.file:
+    path: "{{ nebula_sync_secret_dir }}"
+    state: directory
+    owner: "{{ nebula_sync_secret_file_owner }}"
+    group: "{{ nebula_sync_secret_file_group }}"
+    mode: "0700"
+
+- name: Render nebula-sync primary secret file
+  when: nebula_sync_use_secret_files | bool
+  no_log: true
+  ansible.builtin.copy:
+    dest: "{{ nebula_sync_secret_dir }}/{{ nebula_sync_primary_secret_filename }}"
+    content: "{{ nebula_sync_primary_url }}|{{ nebula_sync_primary_password }}\n"
+    owner: "{{ nebula_sync_secret_file_owner }}"
+    group: "{{ nebula_sync_secret_file_group }}"
+    mode: "0400"
+  register: nebula_sync_primary_secret
+
+- name: Render nebula-sync replicas secret file
+  when: nebula_sync_use_secret_files | bool
+  no_log: true
+  ansible.builtin.copy:
+    dest: "{{ nebula_sync_secret_dir }}/{{ nebula_sync_replicas_secret_filename }}"
+    content: |
+      {% for r in nebula_sync_replicas %}{{ r.url }}|{{ r.password }}{% if not loop.last %},{% endif %}{% endfor %}
+    owner: "{{ nebula_sync_secret_file_owner }}"
+    group: "{{ nebula_sync_secret_file_group }}"
+    mode: "0400"
+  register: nebula_sync_replicas_secret
+
 - name: Render docker-compose.yml
   ansible.builtin.template:
     src: docker-compose.yml.j2
@@ -14,34 +46,58 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0644'
+  register: nebula_sync_compose_template
 
-- name: Render .env (contains Pi-hole passwords) when enabled
+- name: Render .env when enabled
   when: nebula_sync_use_env_file | bool
+  no_log: "{{ nebula_sync_use_secret_files | bool }}"
   ansible.builtin.template:
     src: env.j2
     dest: "{{ nebula_sync_dir }}/{{ nebula_sync_env_filename }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: "0600"
+  register: nebula_sync_env_template
 
 - name: Pull docker image
   community.docker.docker_image_pull:
     name: "{{ nebula_sync_image }}:{{ nebula_sync_image_tag }}"
     platform: "{{ ansible_facts['architecture'] }}"
 
+- name: Determine whether nebula-sync must be recreated
+  ansible.builtin.set_fact:
+    nebula_sync_force_recreate: >-
+      {{
+        (nebula_sync_compose_template.changed | default(false) | bool)
+        or (nebula_sync_env_template.changed | default(false) | bool)
+        or (nebula_sync_primary_secret.changed | default(false) | bool)
+        or (nebula_sync_replicas_secret.changed | default(false) | bool)
+      }}
+
+- name: Build nebula-sync compose up command
+  ansible.builtin.set_fact:
+    nebula_sync_compose_up_argv: >-
+      {{
+        [
+          'docker',
+          'compose',
+          '-f',
+          (nebula_compose_file | default(nebula_sync_dir ~ '/docker-compose.yml')),
+          'up',
+          '-d'
+        ]
+        + (['--force-recreate'] if nebula_sync_force_recreate | bool else [])
+      }}
+
 - name: Bring up nebula-sync with Docker Compose v2
   ansible.builtin.command:
-    argv:
-      - docker
-      - compose
-      - -f
-      - "{{ nebula_compose_file | default(nebula_sync_dir ~ '/docker-compose.yml') }}"
-      - up
-      - -d
+    argv: "{{ nebula_sync_compose_up_argv }}"
   args:
     chdir: "{{ nebula_sync_dir }}"
   register: nebula_sync_compose_up
   changed_when: >
+    nebula_sync_force_recreate | bool
+    or
     nebula_sync_compose_up.stdout is search('(?im)^(creating|recreating|starting|pulling|building)\b')
     or nebula_sync_compose_up.stderr is search('(?im)^(creating|recreating|starting|pulling|building)\b')
   failed_when: nebula_sync_compose_up.rc != 0

--- a/roles/nebula_sync/templates/docker-compose.yml.j2
+++ b/roles/nebula_sync/templates/docker-compose.yml.j2
@@ -3,12 +3,21 @@ services:
     image: "{{ nebula_sync_image }}:{{ nebula_sync_image_tag }}"
     container_name: "{{ nebula_sync_container_name }}"
     restart: unless-stopped
+{% if nebula_sync_use_secret_files | bool %}
+    volumes:
+      - "{{ nebula_sync_secret_dir }}/{{ nebula_sync_primary_secret_filename }}:{{ nebula_sync_secret_container_dir }}/{{ nebula_sync_primary_secret_filename }}:ro"
+      - "{{ nebula_sync_secret_dir }}/{{ nebula_sync_replicas_secret_filename }}:{{ nebula_sync_secret_container_dir }}/{{ nebula_sync_replicas_secret_filename }}:ro"
+{% endif %}
 {% if nebula_sync_use_env_file | bool %}
     env_file:
       - "{{ nebula_sync_env_filename }}"
 {% endif %}
     environment:
-{% if not (nebula_sync_use_env_file | bool) %}
+{% if (nebula_sync_use_secret_files | bool) and not (nebula_sync_use_env_file | bool) %}
+      TZ: "{{ nebula_sync_tz }}"
+      PRIMARY_FILE: "{{ nebula_sync_secret_container_dir }}/{{ nebula_sync_primary_secret_filename }}"
+      REPLICAS_FILE: "{{ nebula_sync_secret_container_dir }}/{{ nebula_sync_replicas_secret_filename }}"
+{% elif not (nebula_sync_use_env_file | bool) %}
       TZ: "{{ nebula_sync_tz }}"
       PRIMARY: "{{ nebula_sync_primary_url }}|{{ nebula_sync_primary_password }}"
       REPLICAS: "{% for r in nebula_sync_replicas %}{{ r.url }}|{{ r.password }}{% if not loop.last %},{% endif %}{% endfor %}"

--- a/roles/nebula_sync/templates/env.j2
+++ b/roles/nebula_sync/templates/env.j2
@@ -1,7 +1,12 @@
 TZ={{ nebula_sync_tz }}
 
+{% if nebula_sync_use_secret_files | bool %}
+PRIMARY_FILE={{ nebula_sync_secret_container_dir }}/{{ nebula_sync_primary_secret_filename }}
+REPLICAS_FILE={{ nebula_sync_secret_container_dir }}/{{ nebula_sync_replicas_secret_filename }}
+{% else %}
 PRIMARY={{ nebula_sync_primary_url }}|{{ nebula_sync_primary_password }}
 REPLICAS={% for r in nebula_sync_replicas %}{{ r.url }}|{{ r.password }}{% if not loop.last %},{% endif %}{% endfor %}
+{% endif %}
 
 FULL_SYNC={{ nebula_sync_full_sync | string | lower }}
 RUN_GRAVITY={{ nebula_sync_run_gravity | string | lower }}


### PR DESCRIPTION
## Summary
- add optional Nebula Sync PRIMARY_FILE / REPLICAS_FILE secret-file rendering and bind mounts
- force Docker Compose recreation when compose, env, or secret files change
- document the new `nebula_sync_use_secret_files` option in the README

## Validation
- `.venv/bin/yamllint roles/nebula_sync playbooks/sync.yaml`
- `ANSIBLE_HOME=/tmp/ansible-pihole-home ANSIBLE_LOCAL_TEMP=/tmp/ansible-pihole-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-pihole-remote .venv/bin/ansible-playbook -i inventory/ci/ci.yml playbooks/sync.yaml --syntax-check`
- `ANSIBLE_HOME=/tmp/ansible-pihole-home ANSIBLE_LOCAL_TEMP=/tmp/ansible-pihole-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-pihole-remote .venv/bin/ansible-lint -p roles/nebula_sync playbooks/sync.yaml`