### PR TITLE
fix(molecule): Ubuntu converge runs sync for Nebula verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Two Vagrant VMs run the real playbooks (see [`molecule/ubuntu/converge.yml`](mol
 | Path | Purpose |
 |------|---------|
 | [`molecule/common/prepare.yml`](molecule/common/prepare.yml) | Shared prepare (Python, `dig`, `ip` — apt vs dnf by OS) |
-| [`molecule/common/verify_ha.yml`](molecule/common/verify_ha.yml) | Shared verify (keepalived, firewalld, DNS, Pi-hole container checks) |
+| [`molecule/common/verify_ha.yml`](molecule/common/verify_ha.yml) | Shared verify (keepalived, firewalld, DNS, Nebula Sync when inventory sets it, Pi-hole container failover) |
 | `molecule/<scenario>/` | `molecule.yml`, `Vagrantfile`, `create.yml`, `destroy.yml`, thin `prepare.yml` / `verify.yml` |
 
 **`molecule test`** sequence: **dependency** (same [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh) as above), **syntax**, **create** (`vagrant up` in the scenario directory), **prepare**, **converge**, **verify**, **destroy**. Localhost lifecycle playbooks use `chdir: "{{ playbook_dir }}"` so Vagrant runs in the right folder.

--- a/molecule/ubuntu/converge.yml
+++ b/molecule/ubuntu/converge.yml
@@ -1,3 +1,5 @@
 ---
 - name: Converge — bootstrap Pi-hole stack
   import_playbook: ../../playbooks/bootstrap-pihole.yaml
+- name: Converge — sync configuration
+  import_playbook: ../../playbooks/sync.yaml


### PR DESCRIPTION
## Summary
Aligns `molecule/ubuntu/converge.yml` with `molecule/default/converge.yml` by importing `playbooks/sync.yaml` after bootstrap so Nebula Sync is deployed before `verify_ha.yml` runs.

## Problem
Inventory (`vagrant.yml`) sets `nebula_sync_primary_url`; verify asserts the Nebula container exists. Ubuntu scenario never ran the sync playbook, so `docker_container_info` reported no container.

## Changes
- `molecule/ubuntu/converge.yml`: import `sync.yaml` after bootstrap.
- `README.md`: note Nebula in shared verify description.

## Workflow
Bugfix branch → `dev` → `master` (follow-up PR after merge).

Made with [Cursor](https://cursor.com)