### PR TITLE
chore: merge dev (Molecule Ubuntu Nebula sync converge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Two Vagrant VMs run the real playbooks (see [`molecule/ubuntu/converge.yml`](mol
 | Path | Purpose |
 |------|---------|
 | [`molecule/common/prepare.yml`](molecule/common/prepare.yml) | Shared prepare (Python, `dig`, `ip` — apt vs dnf by OS) |
-| [`molecule/common/verify_ha.yml`](molecule/common/verify_ha.yml) | Shared verify (keepalived, firewalld, DNS, Pi-hole container checks) |
+| [`molecule/common/verify_ha.yml`](molecule/common/verify_ha.yml) | Shared verify (keepalived, firewalld, DNS, Nebula Sync when inventory sets it, Pi-hole container failover) |
 | `molecule/<scenario>/` | `molecule.yml`, `Vagrantfile`, `create.yml`, `destroy.yml`, thin `prepare.yml` / `verify.yml` |
 
 **`molecule test`** sequence: **dependency** (same [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh) as above), **syntax**, **create** (`vagrant up` in the scenario directory), **prepare**, **converge**, **verify**, **destroy**. Localhost lifecycle playbooks use `chdir: "{{ playbook_dir }}"` so Vagrant runs in the right folder.

--- a/molecule/ubuntu/converge.yml
+++ b/molecule/ubuntu/converge.yml
@@ -1,3 +1,5 @@
 ---
 - name: Converge — bootstrap Pi-hole stack
   import_playbook: ../../playbooks/bootstrap-pihole.yaml
+- name: Converge — sync configuration
+  import_playbook: ../../playbooks/sync.yaml


### PR DESCRIPTION
Promotes latest `dev` to `master`, including the Ubuntu Molecule converge fix so `playbooks/sync.yaml` runs before Nebula verify.

Includes: https://github.com/steveyminecraft/ansible-pihole/pull/54

Made with [Cursor](https://cursor.com)