### PR TITLE
Publish steveyminecraft.pihole Ansible collection to Galaxy

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,8 +8,6 @@ exclude_paths:
   - .github/
   - .ansible/
   - roles/**/.molecule/
-  # Installed from roles/requirements.yml (gitignored); lint upstream in docker-pihole.
-  - roles/pihole/
   - collections/
   - inventory/inventory.yaml
   - playbooks/display.yaml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,20 +30,6 @@ updates:
       - dependencies
       - python
 
-  - package-ecosystem: pip
-    directory: /roles/pihole
-    schedule:
-      interval: weekly
-      day: monday
-      time: "06:00"
-      timezone: Europe/London
-    cooldown:
-      default-days: 5
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - python
-
   - package-ecosystem: pre-commit
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ name: CI - Ansible-Pihole Checks
   workflow_dispatch:
 
 env:
-  # Track the newest supported CPython on GitHub runners.
-  python_version: "3.x"
   # Opt into Node.js 24 for GitHub Actions (silences Node 20 deprecation warnings).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -24,8 +22,12 @@ permissions:
 
 jobs:
   lint:
-    name: Ansible & YAML lint
+    name: Ansible & YAML lint (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
 
     steps:
       - name: Checkout
@@ -36,19 +38,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: ${{ env.python_version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade ansible-core ansible-lint yamllint galaxy-importer
+          python -m pip install --upgrade 'ansible-core>=2.20,<2.21' ansible-lint yamllint galaxy-importer
 
-      - name: Validate role metadata for Ansible Galaxy
+      - name: Build and validate collection for Ansible Galaxy
         run: |
-          cd ..
-          python -m galaxy_importer.main --legacy-role --namespace steveyminecraft "${GITHUB_REPOSITORY#*/}"
+          ansible-galaxy collection build
+          python -m galaxy_importer.main "$(ls -1 steveyminecraft-pihole-*.tar.gz | head -1)"
 
-      - name: Install Galaxy roles and collections
+      - name: Install collections
         run: ./scripts/install-ansible-collections.sh
 
       - name: Ansible Lint
@@ -63,9 +65,13 @@ jobs:
         run: yamllint roles playbooks molecule inventory
 
   ansible-tests-ubuntu:
-    name: Ansible syntax & dry-run
+    name: Ansible syntax & dry-run (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
 
     steps:
       - name: Checkout
@@ -76,17 +82,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: ${{ env.python_version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade ansible-core
+          python -m pip install --upgrade 'ansible-core>=2.20,<2.21'
 
       - name: Show Ansible version
         run: ansible --version
 
-      - name: Install Galaxy roles and collections
+      - name: Install collections
         run: ./scripts/install-ansible-collections.sh
 
       # 1) Syntax-check all main playbooks

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -1,8 +1,11 @@
 ---
-name: Publish to Ansible Galaxy
+name: Validate collection for Ansible Galaxy
 
 on:  # yamllint disable-line rule:truthy
   push:
+    branches:
+      - master
+  pull_request:
     branches:
       - master
   workflow_dispatch:
@@ -11,21 +14,32 @@ permissions:
   contents: read
 
 concurrency:
-  group: galaxy-publish-${{ github.workflow }}-${{ github.ref }}
+  group: galaxy-validate-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  publish:
-    name: Import ansible-pihole role
+  validate:
+    name: Build and validate steveyminecraft.pihole
     runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Import role into Ansible Galaxy
-        uses: ./.github/actions/import-galaxy-role
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          role-name: ansible-pihole
-        env:
-          GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+          python-version: "3.13"
+
+      - name: Install Ansible and galaxy-importer
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade 'ansible-core>=2.20,<2.21' galaxy-importer
+
+      - name: Build collection artifact
+        run: ansible-galaxy collection build
+
+      - name: Validate collection with galaxy-importer
+        run: |
+          artifact="$(ls -1 steveyminecraft-pihole-*.tar.gz | head -1)"
+          python -m galaxy_importer.main "${artifact}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,10 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       publish-galaxy:
-        description: "Import steveyminecraft.ansible-pihole into Ansible Galaxy"
+        description: "Publish steveyminecraft.pihole collection to Ansible Galaxy"
         default: true
         required: false
         type: boolean
-      galaxy-role-name:
-        description: "Galaxy role name"
-        default: ansible-pihole
-        required: false
-        type: string
 
 permissions:
   contents: write
@@ -38,12 +33,53 @@ jobs:
         with:
           generate_release_notes: true
 
-      - name: Import role into Ansible Galaxy
+      - name: Set up Python
         if: >-
           github.event_name == 'workflow_dispatch' && inputs.publish-galaxy
           || github.ref_type == 'tag'
-        uses: ./.github/actions/import-galaxy-role
+        uses: actions/setup-python@v6
         with:
-          role-name: ${{ inputs.galaxy-role-name || 'ansible-pihole' }}
+          python-version: "3.13"
+
+      - name: Sync collection version from release tag
+        if: >-
+          github.event_name == 'workflow_dispatch' && inputs.publish-galaxy
+          || github.ref_type == 'tag'
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="$(python3 -c "import yaml; print(yaml.safe_load(open('galaxy.yml'))['version'])")"
+          fi
+          python3 - <<PY
+          import pathlib
+          import re
+          import sys
+
+          version = "${version}"
+          if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+              sys.exit(f"Invalid collection version: {version}")
+          path = pathlib.Path("galaxy.yml")
+          text = path.read_text(encoding="utf-8")
+          path.write_text(
+              re.sub(r"^version: .*$", f"version: {version}", text, count=1, flags=re.M),
+              encoding="utf-8",
+          )
+          print(f"galaxy.yml version set to {version}")
+          PY
+
+      - name: Build and publish collection to Ansible Galaxy
+        if: >-
+          github.event_name == 'workflow_dispatch' && inputs.publish-galaxy
+          || github.ref_type == 'tag'
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+        run: |
+          python -m pip install --upgrade pip 'ansible-core>=2.20,<2.21' pyyaml
+          ansible-galaxy collection build
+          if [ -z "${GALAXY_API_KEY:-}" ]; then
+            echo "GALAXY_API_KEY is not set; skipping Galaxy publish."
+            exit 0
+          fi
+          artifact="$(ls -1 steveyminecraft-pihole-*.tar.gz | head -1)"
+          ansible-galaxy collection publish "${artifact}" --api-key "${GALAXY_API_KEY}"

--- a/.gitignore
+++ b/.gitignore
@@ -178,7 +178,7 @@ cython_debug/
 .env.leave
 .vagrant
 .tool-versions
-roles/pihole
 .ansible
+steveyminecraft-pihole-*.tar.gz
 inventory/inventory.yaml
 inventory/rnet.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-# Mirror CI: .github/workflows/ci.yml (pip versions pinned there; align when bumping).
+# Mirror CI: Python 3.13/3.14 + ansible-core 2.20.x (.github/workflows/ci.yml).
 repos:
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0

--- a/.yamllint
+++ b/.yamllint
@@ -23,5 +23,4 @@ ignore:
   - .venv-ci
   - .venv-pr
   - .venv-verify
-  - roles/pihole
   - inventory/inventory.yaml

--- a/README.md
+++ b/README.md
@@ -8,20 +8,41 @@ For the upstream Pi-hole container image, see: https://github.com/pi-hole/docker
 
 ## Controller setup (your laptop or CI)
 
-- Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html) (ansible-core 2.15+ is a practical minimum; CI pins a newer release in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
-- Clone this repo and from the **repository root** run:
+- **ansible-core 2.20.x** (see [`requirements.txt`](requirements.txt)).
+- **Python 3.13 or 3.14** for the controller (CI tests both; Ubuntu 26.04 ships 3.14—see [`.python-version`](.python-version)).
+
+```bash
+./scripts/setup-env.sh
+source env/bin/activate
+./scripts/install-ansible-collections.sh
+ansible --version   # ansible-core 2.20.x from env/bin/ansible
+```
+
+Manual venv (if you prefer): `python3.13 -m venv env` or `python3.14 -m venv env`, then `pip install -r requirements.txt`.
+
+This repository is an **Ansible collection** published as **`steveyminecraft.pihole`** on [Ansible Galaxy](https://galaxy.ansible.com/ui/collections/). Collection metadata is in [`galaxy.yml`](galaxy.yml); runtime requirements are in [`meta/runtime.yml`](meta/runtime.yml).
+
+**From Galaxy** (consumers):
+
+```bash
+ansible-galaxy collection install steveyminecraft.pihole
+```
+
+**From a git clone** (development):
 
 ```bash
 ./scripts/install-ansible-collections.sh
 ```
 
-This installs the Pi-hole Galaxy role **`steveyminecraft.docker-pihole`** at **`v1.0.0`** (see [`roles/requirements.yml`](roles/requirements.yml)), applies local role compatibility edits (see [`patches/`](patches/) only if any remain; Pi-hole Galaxy overrides use Python—[`scripts/apply_pihole_redhat_nat_fallback.py`](scripts/apply_pihole_redhat_nat_fallback.py), [`scripts/apply_pihole_unbound_health_wait.py`](scripts/apply_pihole_unbound_health_wait.py), and [`scripts/apply_pihole_galaxy_install_overrides.py`](scripts/apply_pihole_galaxy_install_overrides.py)—so `patch(1)` is not required for those steps on older Ubuntu runners), installs **`ansible.posix` from git** (the merged commit from [ansible.posix PR #690](https://github.com/ansible-collections/ansible.posix/pull/690) with ansible-core 2.24-safe imports until a Galaxy release includes it), then **collections** listed in [`collections/requirements.yml`](collections/requirements.yml). **Git** is required for that `ansible.posix` step.
+That script builds and installs this collection locally, installs **`ansible.posix` from git** (merged [ansible.posix PR #690](https://github.com/ansible-collections/ansible.posix/pull/690) until a Galaxy release includes it), then installs dependencies in [`collections/requirements.yml`](collections/requirements.yml). **Git** is required for the `ansible.posix` step.
 
-Ansible uses [`ansible.cfg`](ansible.cfg) (`roles_path`, `collections_path`) and disables top-level fact injection so roles use `ansible_facts[...]` consistently with ansible-core 2.24+. Re-run the script after changing dependency files.
+[`ansible.cfg`](ansible.cfg) sets `roles_path`, `collections_path`, and disables top-level fact injection so roles use `ansible_facts[...]` with ansible-core 2.20+. Playbooks reference roles by FQCN (for example `steveyminecraft.pihole.pihole`). Re-run the install script after changing [`galaxy.yml`](galaxy.yml) or [`collections/requirements.yml`](collections/requirements.yml).
+
+The Pi-hole Docker role lives in this collection as [`roles/pihole`](roles/pihole/) (sourced from [`docker-pihole`](https://github.com/steveyminecraft/docker-pihole) with ansible-pihole compatibility changes applied in-tree).
 
 ## Base setup (targets)
 
-- Targets can be **Raspberry Pi OS** (as originally documented) or other Linux distros supported by the roles (Molecule uses Ubuntu 24.04 and Rocky-style images).
+- Targets can be **Raspberry Pi OS** (as originally documented) or other Linux distros supported by the roles (Molecule uses Ubuntu 24.04, Ubuntu 26.04, and Rocky-style images).
 - The [openssh_keypair](https://docs.ansible.com/ansible/latest/collections/community/crypto/openssh_keypair_module.html) collection module is pulled in via `collections/requirements.yml`.
 - **Headless Pi** (if applicable): enable SSH, configure user and networking, set static IPs (DHCP reservation is enough).
 - **Inventory:** define hosts and group vars (see examples in [`inventory/vagrant.yml`](inventory/vagrant.yml) for lab-style vars such as `pihole_*`, `nebula_sync_*`, VIPs). There is no single checked-in “production” inventory filename; use `-i` pointing at your file.
@@ -43,7 +64,7 @@ If Docker tasks fail on a first run, reboot the host and re-run.
 Roles include (among others):
 
 - [`bootstrap`](roles/bootstrap/tasks/main.yml): SSH key from GitHub (`github_user_for_ssh_key`), optional password lock, aliases, timezone, hostname, packages such as firewalld on Debian/Ubuntu.
-- [`updates`](roles/updates/tasks/main.yml), [`sshd`](roles/sshd/tasks/main.yml), [`docker`](roles/docker/tasks/main.yml), [`unbound`](roles/unbound/tasks/main.yml), [`pihole`](roles/pihole/tasks/main.yml) (often from Galaxy; see [`roles/requirements.yml`](roles/requirements.yml)), [`keepalived`](roles/keepalived/tasks/main.yml), [`start_keepalived`](roles/start_keepalived/tasks/main.yml) / [`stop_keepalived`](roles/stop_keepalived/tasks/main.yml) as used in the play.
+- [`updates`](roles/updates/tasks/main.yml), [`sshd`](roles/sshd/tasks/main.yml), [`docker`](roles/docker/tasks/main.yml), [`unbound`](roles/unbound/tasks/main.yml), [`pihole`](roles/pihole/tasks/main.yml), [`keepalived`](roles/keepalived/tasks/main.yml), [`start_keepalived`](roles/start_keepalived/tasks/main.yml) / [`stop_keepalived`](roles/stop_keepalived/tasks/main.yml) as used in the play (FQCN prefix `steveyminecraft.pihole.` in playbooks).
 
 On RedHat/Rocky hosts the Docker role installs `kernel-modules-extra` by default for Docker/netfilter support. If a real host already has the needed modules and `/boot` is too tight for kernel package changes, opt out in inventory:
 
@@ -130,18 +151,20 @@ For **idempotence** tuning (second converge should report no changes), run `mole
 | Scenario | Path | Platforms |
 |----------|------|-----------|
 | `ubuntu` | [`molecule/ubuntu/`](molecule/ubuntu/) | Ubuntu 24.04 (`bento/ubuntu-24.04`) |
+| `ubuntu-26.04` | [`molecule/ubuntu-26.04/`](molecule/ubuntu-26.04/) | Ubuntu 26.04 — VirtualBox: `konstruktoid/ubuntu-26.04` (Bento); libvirt: `cloud-image/ubuntu-26.04` |
 | `default` | [`molecule/default/`](molecule/default/) | Rocky-style box (see `molecule.yml`) |
 
 Examples:
 
 ```bash
 molecule test -s ubuntu
+molecule test -s ubuntu-26.04
 molecule converge -s ubuntu    # iterate without full test sequence
 ```
 
 ### VirtualBox vs libvirt and inventory
 
-Private guest IPs depend on the provider (see [`molecule/ubuntu/Vagrantfile`](molecule/ubuntu/Vagrantfile)):
+Private guest IPs depend on the provider (see [`molecule/ubuntu/Vagrantfile`](molecule/ubuntu/Vagrantfile) and [`molecule/ubuntu-26.04/Vagrantfile`](molecule/ubuntu-26.04/Vagrantfile)):
 
 - **VirtualBox** — typically `192.168.56.0/24` → [`inventory/vagrant.yml`](inventory/vagrant.yml)
 - **libvirt** — typically `192.168.121.0/24` → [`inventory/vagrant_libvirt.yml`](inventory/vagrant_libvirt.yml)
@@ -153,6 +176,8 @@ export VAGRANT_DEFAULT_PROVIDER=libvirt
 export MOLECULE_VAGRANT_INVENTORY=vagrant_libvirt.yml
 molecule test -s ubuntu
 ```
+
+**`ubuntu-26.04`:** do not use `cloud-image/ubuntu-26.04` on VirtualBox (vmwgfx DRM errors). The scenario [`Vagrantfile`](molecule/ubuntu-26.04/Vagrantfile) selects **`konstruktoid/ubuntu-26.04`** (Bento build) for VirtualBox and **`cloud-image/ubuntu-26.04`** only for libvirt. After changing boxes, run `molecule destroy -s ubuntu-26.04` then `molecule test -s ubuntu-26.04`.
 
 ### Helper: `scripts/molecule-vagrant`
 
@@ -179,12 +204,14 @@ GitHub Actions workflow [`.github/workflows/ci.yml`](.github/workflows/ci.yml) r
 
 ### Releases and Ansible Galaxy
 
-Galaxy metadata is in [`meta/main.yml`](meta/main.yml) (`role_name` **`ansible_pihole`**; Galaxy listing **`ansible-pihole`**). This repository publishes as **`steveyminecraft.ansible-pihole`** (meta role depending on **`steveyminecraft.docker-pihole`**). The Pi-hole role is maintained in [`docker-pihole`](https://github.com/steveyminecraft/docker-pihole).
+Collection metadata is in [`galaxy.yml`](galaxy.yml). The collection is published as **`steveyminecraft.pihole`** on [galaxy.ansible.com](https://galaxy.ansible.com/ui/collections/). Bump `version` in `galaxy.yml` when preparing a release (release tags `v*.*.*` sync into `galaxy.yml` in CI).
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | [Auto-tag on master](.github/workflows/auto-tag.yml) | Push to `master` | Bumps `v*.*.*` tags on this repo (starts at `v1.0.0`) |
-| [Publish to Ansible Galaxy](.github/workflows/galaxy-publish.yml) | Push to `master`, manual | Imports `steveyminecraft.ansible-pihole` from this repository |
-| [Release](.github/workflows/release.yml) | Tag `v*`, manual | GitHub release plus Galaxy import |
+| [Validate collection for Ansible Galaxy](.github/workflows/galaxy-publish.yml) | Push/PR to `master`, manual | Builds the collection artifact and runs `galaxy-importer` |
+| [Release](.github/workflows/release.yml) | Tag `v*`, manual | GitHub release plus `ansible-galaxy collection publish` |
 
 Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key). Skip auto-tagging with `[skip tag]` in the commit message.
+
+Legacy Galaxy **roles** `steveyminecraft.ansible-pihole` and `steveyminecraft.docker-pihole` are superseded by this collection; use `ansible-galaxy collection install steveyminecraft.pihole` instead.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 roles_path = ./roles
 collections_path = ./.ansible/collections:./collections
-# Align with ansible-core 2.24+; facts live under ansible_facts only (no top-level ansible_* mirrors).
+# FQCN roles (steveyminecraft.pihole.*) resolve after scripts/install-ansible-collections.sh.
+# Align with ansible-core 2.20+; facts live under ansible_facts only (no top-level ansible_* mirrors).
 inject_facts_as_vars = False

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,28 @@
+---
+namespace: steveyminecraft
+name: pihole
+version: 1.0.0
+readme: README.md
+authors:
+  - steveyminecraft
+description: >-
+  Deploy Pi-hole with Docker, optional Unbound, keepalived HA, and Nebula Sync.
+  Includes playbooks for bootstrap, updates, and configuration sync.
+license:
+  - MIT
+tags:
+  - pihole
+  - docker
+  - dns
+  - ha
+  - keepalived
+  - unbound
+  - ansible
+repository: https://github.com/steveyminecraft/ansible-pihole
+documentation: https://github.com/steveyminecraft/ansible-pihole#readme
+homepage: https://github.com/steveyminecraft/ansible-pihole
+issues: https://github.com/steveyminecraft/ansible-pihole/issues
+dependencies:
+  community.docker: ">=3.10.0"
+  community.crypto: ">=2.20.0"
+  community.general: ">=9.0.0"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.20.0"

--- a/molecule/default/converge-docker.yml
+++ b/molecule/default/converge-docker.yml
@@ -6,4 +6,4 @@
   vars:
     docker_manage_iptables: false
   roles:
-    - role: docker
+    - role: steveyminecraft.pihole.docker

--- a/playbooks/bootstrap-pihole.yaml
+++ b/playbooks/bootstrap-pihole.yaml
@@ -4,21 +4,21 @@
   become: true
   serial: 1
   roles:
-    - role: stop_keepalived
+    - role: steveyminecraft.pihole.stop_keepalived
       tags: [stopkeepalived, drain, ha]
-    - role: bootstrap
+    - role: steveyminecraft.pihole.bootstrap
       tags: [bootstrap, system]
-    - role: updates
+    - role: steveyminecraft.pihole.updates
       tags: [updates, system]
-    - role: sshd
+    - role: steveyminecraft.pihole.sshd
       tags: [sshd, system]
-    - role: keepalived
+    - role: steveyminecraft.pihole.keepalived
       tags: [keepalived, ha]
-    - role: docker
+    - role: steveyminecraft.pihole.docker
       tags: [docker, container]
-    - role: unbound
+    - role: steveyminecraft.pihole.unbound
       tags: [unbound, dns]
-    - role: pihole
+    - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
-    - role: start_keepalived
+    - role: steveyminecraft.pihole.start_keepalived
       tags: [startkeepalived, resume, ha]

--- a/playbooks/ci-bootstrap.yaml
+++ b/playbooks/ci-bootstrap.yaml
@@ -23,14 +23,14 @@
     pihole_compose_dir: "/opt/pihole"
 
   roles:
-    - role: bootstrap
+    - role: steveyminecraft.pihole.bootstrap
       tags: [bootstrap, system]
     # In --check mode, apt repo changes aren't applied, which makes Docker packages
     # appear "missing" and fails the dry-run. Docker is exercised elsewhere (lint/molecule);
     # CI check-mode should stay side-effect free.
-    - role: docker
+    - role: steveyminecraft.pihole.docker
       tags: [docker, container]
       when: not ansible_check_mode
-    - role: pihole
+    - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
       when: not ansible_check_mode

--- a/playbooks/keepalived.yaml
+++ b/playbooks/keepalived.yaml
@@ -4,9 +4,9 @@
   become: true
   serial: 1
   roles:
-    - role: stop_keepalived
+    - role: steveyminecraft.pihole.stop_keepalived
       tags: [stopkeepalived, drain, ha]
-    - role: keepalived
+    - role: steveyminecraft.pihole.keepalived
       tags: [keepalived, ha]
-    - role: start_keepalived
+    - role: steveyminecraft.pihole.start_keepalived
       tags: [startkeepalived, resume, ha]

--- a/playbooks/sync.yaml
+++ b/playbooks/sync.yaml
@@ -4,5 +4,5 @@
   become: true
   serial: 1
   roles:
-    - role: nebula_sync
+    - role: steveyminecraft.pihole.nebula_sync
       tags: [nebulasync, nebula, sync]

--- a/playbooks/update-pihole.yaml
+++ b/playbooks/update-pihole.yaml
@@ -4,11 +4,11 @@
   become: true
   serial: 1
   roles:
-    - role: stop_keepalived
+    - role: steveyminecraft.pihole.stop_keepalived
       tags: [stopkeepalived, drain, ha]
-    - role: updates
+    - role: steveyminecraft.pihole.updates
       tags: [updates, system]
-    - role: pihole
+    - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
-    - role: start_keepalived
+    - role: steveyminecraft.pihole.start_keepalived
       tags: [startkeepalived, resume, ha]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-molecule 
-ansible 
-molecule-vagrant 
-testinfra
-molecule-docker
-python-docker
-ansible-lint
-yamllint
+# Controller toolchain (Python 3.13 or 3.14). CI tests both in .github/workflows/ci.yml.
+ansible-core>=2.20,<2.21
+ansible-lint>=26.4.0
+yamllint>=1.38.0
+molecule>=26.4.0
+molecule-vagrant>=2.0.0
+molecule-docker>=2.1.0
+testinfra>=6.0.0
+python-docker>=0.2.0

--- a/roles/bootstrap/README.md
+++ b/roles/bootstrap/README.md
@@ -1,0 +1,5 @@
+# bootstrap
+
+Initial host setup: SSH keys, packages, timezone, hostname, and related baseline configuration.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,0 +1,5 @@
+# docker
+
+Install and configure Docker Engine and Docker Compose for Pi-hole deployment targets.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -1,0 +1,5 @@
+# keepalived
+
+Configure keepalived for Pi-hole high availability with VIP failover.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/nebula_sync/README.md
+++ b/roles/nebula_sync/README.md
@@ -1,0 +1,5 @@
+# nebula_sync
+
+Deploy Nebula Sync to replicate Pi-hole configuration between HA nodes.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/pihole/.ansible-lint
+++ b/roles/pihole/.ansible-lint
@@ -1,0 +1,4 @@
+---
+# Vendored from docker-pihole; upstream variable names predate pihole_ prefix convention.
+skip_list:
+  - var-naming

--- a/roles/pihole/LICENSE
+++ b/roles/pihole/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -1,0 +1,7 @@
+# pihole
+
+Deploy Pi-hole in Docker (Pi-hole v6) with optional Unbound upstream integration.
+
+Sourced from [docker-pihole](https://github.com/steveyminecraft/docker-pihole) with ansible-pihole compatibility changes applied in this collection.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT-0
+---
+# defaults file for docker-pihole
+# Full list can be found here https://hub.docker.com/r/pihole/pihole
+#
+# Host layout: persistent dirs live under dir_loc (etc/pihole, etc/dnsmasq.d). Compose
+# defaults to the same tree. Inventory usually sets pihole_compose_dir; tasks/main.yml
+# aligns dir_loc so volume paths match the playbook.
+dir_loc: '/opt/pihole'
+pihole_compose_dir: "{{ dir_loc }}"
+firewall_deploy: false
+
+# Must stay aligned with roles/docker/defaults — same variable is used in both roles; last role used to
+# win in defaults, so a literal `true` here overwrote the docker role and broke EL/Vagrant bridge egress.
+# EL Docker NAT fallback after compose (see tasks/redhat_nat_fallback.yml).
+docker_manage_iptables: "{{ not (vagrant_env | default(false) | bool) }}"
+docker_el_nat_fallback: true
+
+# Opt-in Rocky/EL lab mode: stop firewalld, install bind-utils (dig on the host), run Pi-hole
+# container privileged with relaxed seccomp/SELinux labels. Molecule default scenario sets this
+# in molecule/default/group_vars/all.yml — unset for production.
+pihole_rocky_network_debug: false
+# Only used when pihole_rocky_network_debug — flushes all nft rules (see rocky_network_debug.yml).
+pihole_rocky_network_debug_flush_nft: false
+
+# Use host networking for the Pi-hole container (bypasses Docker bridge/NAT entirely).
+# Helpful for Rocky/Vagrant debugging when published 53/udp or bridge DNS is unreliable.
+pihole_use_host_network: false
+
+# When true on Debian/Ubuntu, disable systemd-resolved stub DNS so host port 53 can be used
+# by Docker (Pi-hole publish). Independent of firewalld — do not tie this to firewall_deploy.
+pihole_configure_systemd_resolved: true
+pihole_environment_variables:
+  # Set the appropriate timezone for your location (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g:
+  TZ: 'Europe/London'
+  # Set a password to access the web interface. Not setting one will result in a random password being assigned
+  FTLCONF_webserver_api_password: 'Testing 101'
+  # If using Docker's default `bridge` network setting the dns listening mode should be set to 'ALL'
+  FTLCONF_dns_listeningMode: 'ALL'
+  # controls if required port is opened
+  DHCP_ACTIVE: false
+  REV_SERVER: false
+  REV_SERVER_CIDR: "192.168.56.0/24"
+  REV_SERVER_TARGET: "192.168.56.1"
+
+webport_http: '80'
+webport_https: '443'
+# Compose paths
+pihole_compose_file: "{{ pihole_compose_dir }}/docker-compose.yml"
+
+# Container name (used by unbound.yml checks)
+pihole_container_name: "pihole"
+
+# Docker Compose `dns:` for the Pi-hole service. Keep empty by default so Docker's
+# embedded resolver can resolve shared-network service names such as `unbound`.
+pihole_docker_dns: []
+
+# QNAME used in Unbound integration checks (from host / from Pi-hole container)
+pihole_unbound_verify_qname: "cloudflare.com"

--- a/roles/pihole/files/docker_network_subnet_print.py
+++ b/roles/pihole/files/docker_network_subnet_print.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Print Docker network IPv4 subnets from `docker network inspect` JSON on stdin."""
+import json
+import sys
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    data = json.loads(raw) if raw.strip() else []
+    for net in data:
+        for cfg in (net.get("IPAM") or {}).get("Config") or []:
+            sn = cfg.get("Subnet")
+            if sn:
+                print(sn)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/pihole/handlers/main.yml
+++ b/roles/pihole/handlers/main.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT-0
+---
+# handlers file for docker-pihole
+- name: Stop resolver
+  ansible.builtin.service:
+    name: systemd-resolved
+    state: stopped
+
+- name: Restart resolver
+  ansible.builtin.service:
+    name: systemd-resolved
+    state: restarted
+
+- name: Docker service restart
+  ansible.builtin.service:
+    name: docker
+    state: restarted
+    enabled: true

--- a/roles/pihole/meta/main.yml
+++ b/roles/pihole/meta/main.yml
@@ -1,12 +1,9 @@
 ---
 galaxy_info:
   namespace: steveyminecraft
-  role_name: ansible_pihole
+  role_name: pihole
   author: steveyminecraft
-  description: >-
-    Playbooks and roles to deploy Pi-hole with Docker, optional Unbound,
-    keepalived HA, and Nebula Sync. Clone this repository and run playbooks
-    from playbooks/; Galaxy install declares the Pi-hole role dependency.
+  description: Deploy Pi-hole using Docker (Pi-hole v6, optional Unbound upstream)
   issue_tracker_url: https://github.com/steveyminecraft/ansible-pihole/issues
 
   license: MIT
@@ -31,12 +28,8 @@ galaxy_info:
     - pihole
     - docker
     - dns
-    - ha
-    - keepalived
+    - adblock
     - unbound
-    - ansible
-    - playbook
+    - networking
 
-dependencies:
-  - role: steveyminecraft.docker-pihole
-    version: v1.0.0
+dependencies: []

--- a/roles/pihole/tasks/debian.yml
+++ b/roles/pihole/tasks/debian.yml
@@ -1,0 +1,12 @@
+---
+- name: Install Python3-pip
+  ansible.builtin.apt:
+    name: python3-pip
+    state: present
+
+- name: Ensure firwewalld is installed
+  ansible.builtin.apt:
+    name: firewalld
+    state: present
+  become: true
+  when: firewall_deploy | lower == 'true'

--- a/roles/pihole/tasks/deploypi.yml
+++ b/roles/pihole/tasks/deploypi.yml
@@ -1,0 +1,98 @@
+---
+- name: Create pihole directory
+  ansible.builtin.file:
+    path: "{{ pihole_compose_dir }}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy Docker Compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ pihole_compose_dir }}/docker-compose.yml"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0644'
+  register: pihole_compose_template
+
+- name: Pull docker image
+  community.docker.docker_image_pull:
+    name: "{{ pihole_image }}"
+    platform: "{{ ansible_facts['architecture'] }}"
+
+# Free 127.0.0.1:53 / avoid stub on 127.0.0.53 fighting Docker-published Pi-hole DNS.
+# Not gated on firewall_deploy — firewalld and resolved are separate concerns.
+- name: Configure systemd-resolved for Pi-hole (Debian family)
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - ansible_facts['distribution'] in ['Ubuntu', 'Debian']
+    - pihole_configure_systemd_resolved | default(true) | bool
+
+  block:
+    - name: Disable stub listener
+      ansible.builtin.replace:
+        path: /etc/systemd/resolved.conf
+        regexp: '^#?DNSStubListener=.*'
+        replace: 'DNSStubListener=no'
+
+    - name: Disable DNSStubListener in systemd-resolved configuration
+      ansible.builtin.lineinfile:
+        path: /etc/systemd/resolved.conf
+        regexp: '^#?DNSStubListener='
+        line: 'DNSStubListener=no'
+        backup: true
+
+    - name: Remove /etc/resolv.conf if it exists
+      ansible.builtin.file:
+        path: /etc/resolv.conf
+        state: absent
+
+    - name: Create symlink for resolv.conf
+      ansible.builtin.file:
+        src: /run/systemd/resolve/resolv.conf
+        dest: /etc/resolv.conf
+        state: link
+
+    - name: Restart systemd-resolved
+      ansible.builtin.service:
+        name: systemd-resolved
+        state: restarted
+      failed_when: false
+
+# Bounce Docker so daemon picks up /etc/docker/daemon.json (e.g. iptables: false) before we bring up
+# project networks. EL bridge egress still needs the nft MASQ block after `compose up` (redhat_nat_fallback).
+- name: Restart docker
+  ansible.builtin.service:
+    name: docker
+    state: restarted
+
+- name: Start Pi-hole service (docker compose)
+  vars:
+    _pihole_compose_needs_recreate: >-
+      {{
+        (not (docker_manage_iptables | default(true) | bool))
+        or (pihole_compose_template.changed | default(false) | bool)
+      }}
+    _pihole_compose_recreate_flag: "{{ ' --force-recreate' if _pihole_compose_needs_recreate else '' }}"
+  ansible.builtin.command:
+    cmd: >-
+      docker compose
+      -f {{ pihole_compose_file | default(pihole_compose_dir ~ '/docker-compose.yml') }}
+      up -d{{ _pihole_compose_recreate_flag }}
+  args:
+    chdir: "{{ pihole_compose_dir }}"
+  register: pihole_compose_up
+  changed_when: >-
+    pihole_compose_up.stdout is search('(?im)^(creating|recreating|starting|pulling|building)\\b')
+    or pihole_compose_up.stderr is search('(?im)^(creating|recreating|starting|pulling|building)\\b')
+  failed_when: pihole_compose_up.rc != 0
+
+# Compose creates project networks (e.g. pihole_default); NAT must match real IPAM subnets.
+- name: Refresh EL Docker NAT rules after compose networks exist
+  ansible.builtin.include_tasks:
+    file: "{{ role_path }}/tasks/redhat_nat_fallback.yml"
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - not (docker_manage_iptables | default(true) | bool)
+    - docker_el_nat_fallback | default(true) | bool

--- a/roles/pihole/tasks/firewall.yml
+++ b/roles/pihole/tasks/firewall.yml
@@ -1,0 +1,37 @@
+---
+- name: Enable firewalld ports
+  ansible.posix.firewalld:
+    port: "{{ item }}"
+    state: enabled
+    permanent: true
+    immediate: true
+    zone: public
+  loop:
+    - "{{ webport_http }}/tcp"
+    - "{{ webport_https }}/tcp"
+    - "53/tcp"
+    - "53/udp"
+
+- name: Bootps firewalld rule
+  ansible.posix.firewalld:
+    service: "{{ item }}"
+    state: enabled
+    permanent: true
+    immediate: true
+    zone: public
+  with_items:
+    - bootps
+  when: pihole_environment_variables.REV_SERVER
+
+- name: Check if DHCP is enabled
+  ansible.builtin.set_fact:
+    pihole_dhcp_enabled: "{{ pihole_environment_variables.DHCP_ACTIVE | lower == 'true' }}"
+
+- name: Allow DHCP port in the firewall (if enabled)
+  ansible.posix.firewalld:
+    service: dhcp
+    permanent: true
+    state: enabled
+    immediate: true
+  when: pihole_dhcp_enabled
+  become: true

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Main task file for Pi-hole setup using Ansible
+- name: Combine pihole_environment_variables with inventory values take precedence
+  ansible.builtin.set_fact:
+    pihole_environment_variables: "{{ vars_pihole_environment_variables | default({}) | combine(pihole_environment_variables, recursive=True) }}"
+
+# Inventory often sets pihole_compose_dir only; pre.yml and docker volumes use dir_loc.
+# Keep a single effective root so bind-mount paths match compose and deploypi chdir.
+- name: Align dir_loc with pihole_compose_dir from inventory
+  ansible.builtin.set_fact:
+    dir_loc: "{{ pihole_compose_dir | default(dir_loc | default('/opt/pihole')) }}"
+
+# Inventory often sets pihole_firewall_deploy; role tasks use firewall_deploy.
+- name: Honor inventory pihole_firewall_deploy for firewall_deploy
+  ansible.builtin.set_fact:
+    firewall_deploy: "{{ pihole_firewall_deploy | bool }}"
+  when: pihole_firewall_deploy is defined
+
+- name: Debian setup tasks
+  ansible.builtin.include_tasks: debian.yml
+  when: ansible_facts['distribution'] in ['Debian', 'Ubuntu']
+
+- name: Redhat setup tasks
+  ansible.builtin.include_tasks: redhat.yml
+  when: ansible_facts['distribution'] in ['Rocky', 'Red Hat Enterprise Linux']
+
+- name: Rocky networking debug (firewall off, dig on host, privileged container — opt-in)
+  ansible.builtin.include_tasks: rocky_network_debug.yml
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution'] in ['Rocky', 'Red Hat Enterprise Linux']
+    - pihole_rocky_network_debug | default(false) | bool
+
+- name: Deploy Pi-hole container
+  ansible.builtin.include_tasks: deploypi.yml
+
+- name: Configure firewall
+  ansible.builtin.include_tasks: firewall.yml
+  when: firewall_deploy | lower == 'true'
+
+- name: Added Unbound
+  ansible.builtin.include_tasks: unbound.yml
+  when: not (pihole_use_host_network | default(false) | bool)
+
+- name: Verify Pi-hole deployment
+  ansible.builtin.include_tasks: verify.yml

--- a/roles/pihole/tasks/redhat.yml
+++ b/roles/pihole/tasks/redhat.yml
@@ -1,0 +1,16 @@
+---
+- name: Install python3 pip
+  ansible.builtin.dnf:
+    name: python3-pip
+    state: present
+
+- name: Install python-requests
+  ansible.builtin.dnf:
+    name: python-requests
+    state: present
+
+- name: Install firewalls
+  ansible.builtin.dnf:
+    name: firewalld
+    state: present
+  when: firewall_deploy | lower == 'true'

--- a/roles/pihole/tasks/redhat_nat_fallback.yml
+++ b/roles/pihole/tasks/redhat_nat_fallback.yml
@@ -1,0 +1,109 @@
+---
+# With "iptables": false Docker does not add MASQUERADE. Discover each bridge IPv4 subnet
+# (docker network inspect JSON) and add matching masquerade rules.
+#
+# On EL9+ with iptables-nf_tables, `iptables -j MASQUERADE` often fails (xt_MASQUERADE absent);
+# use a dedicated nftables table instead. No firewall-cmd --reload.
+- name: Ensure nftables is installed for NAT fallback (RedHat)
+  ansible.builtin.dnf:
+    name: nftables
+    state: present
+    lock_timeout: 300
+  when: ansible_facts['os_family'] == 'RedHat'
+
+# Copy the helper to the *guest* (controller role_path in a remote shell is wrong for Galaxy installs).
+# Same logic as files/docker_network_subnet_print.py; roles/docker uses an inline -c to avoid a copy.
+- name: Install Docker network subnet JSON helper on target
+  ansible.builtin.copy:
+    src: docker_network_subnet_print.py
+    dest: "{{ pihole_compose_dir }}/docker_network_subnet_print.py"
+    mode: "0755"
+  when: ansible_facts['os_family'] == 'RedHat'
+- name: Discover Docker IPv4 subnets (dynamic)
+  ansible.builtin.shell:
+    cmd: |
+      set -euo pipefail
+      if ! command -v docker >/dev/null 2>&1; then
+        exit 0
+      fi
+      H='{{ pihole_compose_dir }}/docker_network_subnet_print.py'
+      declare -A seen=()
+      while read -r id; do
+        [ -z "${id:-}" ] && continue
+        while IFS= read -r cidr; do
+          [ -z "${cidr:-}" ] && continue
+          [[ "$cidr" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]] || continue
+          seen["$cidr"]=1
+        done < <(docker network inspect "$id" 2>/dev/null | python3 "$H" 2>/dev/null || true)
+      done < <(docker network ls -q 2>/dev/null || true)
+      for k in "${!seen[@]}"; do
+        printf '%s\n' "$k"
+      done | sort -u
+    executable: /bin/bash
+  register: _docker_nat_subnets
+  changed_when: false
+  failed_when: false
+
+- name: Compute NAT fallback subnet list
+  ansible.builtin.set_fact:
+    docker_nat_fallback_subnets: >-
+      {{
+        (
+          (_docker_nat_subnets.stdout_lines | default([]))
+          | map('trim')
+          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+$')
+          | list
+          | unique
+        )
+        if (
+          (_docker_nat_subnets.stdout_lines | default([]))
+          | map('trim')
+          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/[0-9]+$')
+          | list
+          | length
+        ) > 0
+        else ['172.16.0.0/12']
+      }}
+
+- name: Apply Docker bridge egress NAT (nftables masquerade)
+  ansible.builtin.shell:
+    cmd: |
+      set -euo pipefail
+      for m in nf_conntrack nf_nat nft_chain_nat nft_nat nft_masq; do
+        modprobe "$m" 2>/dev/null || true
+      done
+      if ! command -v nft >/dev/null 2>&1; then
+        echo "nft not found; install nftables" >&2
+        exit 1
+      fi
+      timeout 20s nft delete table ip ansible_docker_nat 2>/dev/null || true
+      timeout 20s nft add table ip ansible_docker_nat
+      timeout 20s nft add chain ip ansible_docker_nat postrouting '{ type nat hook postrouting priority 100; policy accept; }'
+      echo CHANGED
+    executable: /bin/bash
+  register: _docker_nat_nft
+  changed_when: "'CHANGED' in (_docker_nat_nft.stdout | default(''))"
+
+- name: Add nftables masquerade rules per Docker subnet
+  ansible.builtin.command:
+    argv:
+      - timeout
+      - "20s"
+      - nft
+      - add
+      - rule
+      - ip
+      - ansible_docker_nat
+      - postrouting
+      - ip
+      - saddr
+      - "{{ item }}"
+      - ip
+      - daddr
+      - "!="
+      - "{{ item }}"
+      - masquerade
+  register: _docker_nat_rules
+  changed_when: true
+  loop: "{{ docker_nat_fallback_subnets }}"
+

--- a/roles/pihole/tasks/redhat_nat_fallback.yml
+++ b/roles/pihole/tasks/redhat_nat_fallback.yml
@@ -106,4 +106,3 @@
   register: _docker_nat_rules
   changed_when: true
   loop: "{{ docker_nat_fallback_subnets }}"
-

--- a/roles/pihole/tasks/rocky_network_debug.yml
+++ b/roles/pihole/tasks/rocky_network_debug.yml
@@ -1,0 +1,22 @@
+---
+# Opt-in isolation for Rocky/EL + Docker when DNS or published ports misbehave (Molecule / lab).
+# Does not flush nftables by default — that wipes Docker-related tables and our NAT fallback;
+# set pihole_rocky_network_debug_flush_nft: true only if you will re-run the docker NAT tasks after.
+- name: Install bind-utils (dig) on host for DNS debugging
+  ansible.builtin.dnf:
+    name: bind-utils
+    state: present
+    lock_timeout: 300
+
+- name: Stop and disable firewalld (host firewall)
+  ansible.builtin.service:
+    name: firewalld
+    state: stopped
+    enabled: false
+  failed_when: false
+
+- name: Optionally flush entire nftables ruleset (nuclear; breaks tables until Docker/NAT re-applied)
+  ansible.builtin.command: nft flush ruleset
+  changed_when: true
+  failed_when: false
+  when: pihole_rocky_network_debug_flush_nft | default(false) | bool

--- a/roles/pihole/tasks/unbound.yml
+++ b/roles/pihole/tasks/unbound.yml
@@ -1,0 +1,302 @@
+---
+- name: Check if Unbound container exists and is running
+  ansible.builtin.command:
+    cmd: docker inspect -f '{{ "{{" }}.State.Running{{ "}}" }}' "{{ unbound_container_name | default('unbound') }}"
+  register: unbound_running
+  changed_when: false
+  failed_when: false
+
+- name: Set fact if Unbound is running
+  ansible.builtin.set_fact:
+    pihole_unbound_present: "{{ (unbound_running.rc == 0) and (unbound_running.stdout | trim == 'true') }}"
+
+- name: Set docker inspect format
+  ansible.builtin.set_fact:
+    docker_inspect_networks_fmt: "{{ '{{json .NetworkSettings.Networks}}' }}"
+  when: pihole_unbound_present
+
+- name: Inspect Unbound container networks
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - --format
+      - "{{ docker_inspect_networks_fmt }}"
+      - "{{ unbound_container_name | default('unbound') }}"
+  register: unbound_net_json
+  changed_when: false
+  failed_when: unbound_net_json.rc != 0
+  when: pihole_unbound_present
+
+- name: Set Unbound container primary IPv4 for Pi-hole upstream
+  ansible.builtin.set_fact:
+    pihole_unbound_container_ipv4: >-
+      {{
+        (
+          unbound_net_json.stdout | from_json
+          | dict2items
+          | map(attribute='value.IPAddress')
+          | reject('equalto', '')
+          | list
+          | first
+          | default('', true)
+        )
+      }}
+  when: pihole_unbound_present
+
+- name: Set Pi-hole Unbound DNS target
+  ansible.builtin.set_fact:
+    pihole_unbound_dns_target: >-
+      {{
+        pihole_unbound_container_ipv4
+        if (pihole_unbound_container_ipv4 | default('') | length > 0)
+        else (unbound_container_name | default('unbound'))
+      }}
+  when: pihole_unbound_present
+
+- name: Use public DNS as Pi-hole container startup resolver
+  ansible.builtin.set_fact:
+    pihole_docker_dns: "{{ pihole_startup_dns | default(['8.8.8.8', '8.8.4.4']) }}"
+  when:
+    - pihole_unbound_present
+    - pihole_unbound_container_ipv4 | default('') | length > 0
+
+- name: Ensure shared external docker network exists (dns_net)
+  ansible.builtin.command:
+    cmd: docker network inspect "{{ pihole_network_name | default(pihole_unbound_network_name | default('dns_net')) }}"
+  register: dns_net_inspect
+  changed_when: false
+  failed_when: false
+  when: pihole_unbound_present
+
+- name: Create shared external docker network if missing
+  ansible.builtin.command:
+    cmd: docker network create "{{ pihole_network_name | default(pihole_unbound_network_name | default('dns_net')) }}"
+  register: dns_net_create
+  changed_when: dns_net_create.rc == 0
+  failed_when: dns_net_create.rc != 0
+  when: pihole_unbound_present and dns_net_inspect.rc != 0
+
+- name: Enable Pi-hole upstream to Unbound (set env vars)
+  ansible.builtin.set_fact:
+    pihole_environment_variables: >-
+      {{
+        (pihole_environment_variables | default({}))
+        | combine({
+            'FTLCONF_dns_upstreams': ((pihole_unbound_dns_target | default(unbound_container_name | default('unbound'))) ~ '#' ~ (unbound_port | default(5335) | string)),
+            'FTLCONF_dns_listeningMode': 'all'
+          }, recursive=True)
+      }}
+  when: pihole_unbound_present
+
+- name: Re-render docker-compose.yml for Pi-hole (with Unbound integration)
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ pihole_compose_file }}"
+    mode: "0644"
+  when: pihole_unbound_present
+
+- name: Apply compose changes (Pi-hole)
+  ansible.builtin.command:
+    cmd: docker compose -f "{{ pihole_compose_file }}" up -d --force-recreate
+  args:
+    chdir: "{{ pihole_compose_dir }}"
+  register: pihole_compose_up
+  changed_when: >
+    pihole_compose_up.stdout is search('(?im)^(creating|recreating|starting|pulling|building)\\b')
+    or pihole_compose_up.stderr is search('(?im)^(creating|recreating|starting|pulling|building)\\b')
+  failed_when: pihole_compose_up.rc != 0
+  when: pihole_unbound_present
+
+- name: Override Pi-hole container resolv.conf when Docker DNS redirect is unavailable
+  ansible.builtin.shell:
+    cmd: docker exec -i "{{ pihole_container_name | default('pihole') }}" sh -c 'cat > /etc/resolv.conf'
+    stdin: |
+      {% for nameserver in pihole_docker_dns | default([]) %}
+      nameserver {{ nameserver }}
+      {% endfor %}
+      options ndots:0
+  changed_when: true
+  when:
+    - pihole_unbound_present
+    - not (docker_manage_iptables | default(true) | bool)
+    - pihole_docker_dns | default([]) | length > 0
+
+- name: Inspect Docker DNS network for attached containers
+  ansible.builtin.command:
+    argv:
+      - docker
+      - network
+      - inspect
+      - "{{ pihole_network_name | default(pihole_unbound_network_name | default('dns_net')) }}"
+  register: pihole_dns_net_json
+  changed_when: false
+  failed_when: pihole_dns_net_json.rc != 0
+  when: pihole_unbound_present
+
+- name: Derive names of containers on the shared DNS network
+  ansible.builtin.set_fact:
+    pihole_dns_net_container_names: >-
+      {{
+        (
+          (pihole_dns_net_json.stdout | from_json | first).Containers | default({})
+          | dict2items
+          | map(attribute='value.Name')
+          | map('regex_replace', '^/', '')
+          | list
+        )
+      }}
+  when: pihole_unbound_present
+
+- name: Assert Pi-hole and Unbound share the same Docker network
+  ansible.builtin.assert:
+    that:
+      - (pihole_container_name | default('pihole')) in pihole_dns_net_container_names
+      - (unbound_container_name | default('unbound')) in pihole_dns_net_container_names
+    fail_msg: >-
+      Pi-hole is configured to use Unbound upstream, but both containers must be attached to Docker network
+      '{{ pihole_network_name | default(pihole_unbound_network_name | default('dns_net')) }}'.
+      Attached: {{ pihole_dns_net_container_names | default([]) }}.
+      Set inventory var pihole_network_name to match unbound_network_name and ensure docker-compose.yml.j2 attaches Pi-hole to that network.
+  when: pihole_unbound_present
+
+- name: From host, verify Unbound answers on published loopback port (if enabled)
+  ansible.builtin.command:
+    argv:
+      - dig
+      - -p
+      - "{{ unbound_publish_host_port | default(unbound_port | default(5335)) | string }}"
+      - +short
+      - +time=3
+      - +tries=2
+      - "{{ pihole_unbound_verify_qname | default('cloudflare.com') }}"
+      - "@127.0.0.1"
+  register: pihole_host_unbound_dig
+  changed_when: false
+  failed_when: false
+  when:
+    - pihole_unbound_present
+    - unbound_publish_to_host | default(false) | bool
+
+- name: Set docker inspect format
+  ansible.builtin.set_fact:
+    docker_inspect_networks_fmt: "{{ '{{json .NetworkSettings.Networks}}' }}"
+  when: pihole_unbound_present
+
+- name: Inspect Unbound container networks
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - --format
+      - "{{ docker_inspect_networks_fmt }}"
+      - "{{ unbound_container_name | default('unbound') }}"
+  register: unbound_net_json
+  changed_when: false
+  failed_when: unbound_net_json.rc != 0
+  when: pihole_unbound_present
+
+- name: Set Unbound container primary IPv4 for host-side dig
+  ansible.builtin.set_fact:
+    pihole_unbound_container_ipv4: >-
+      {{
+        (
+          unbound_net_json.stdout | from_json
+          | dict2items
+          | map(attribute='value.IPAddress')
+          | reject('equalto', '')
+          | list
+          | first
+          | default('', true)
+        )
+      }}
+  when: pihole_unbound_present
+
+- name: From host, dig Unbound on its container IPv4
+  ansible.builtin.command:
+    argv:
+      - dig
+      - -p
+      - "{{ unbound_port | default(5335) | string }}"
+      - +short
+      - +time=3
+      - +tries=2
+      - "{{ pihole_unbound_verify_qname }}"
+      - "@{{ pihole_unbound_container_ipv4 }}"
+  register: pihole_host_unbound_dig_bridge
+  changed_when: false
+  failed_when: >
+    (pihole_host_unbound_dig_bridge.stdout_lines | default([])
+    | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+    | list | length) == 0
+  when:
+    - pihole_unbound_present
+    - pihole_unbound_container_ipv4 | default('') | length > 0
+
+# Wait for Pi-hole to be ready enough for functional checks. Docker health can remain
+# "starting" during the image start period even while DNS is already available.
+- name: Wait until Pi-hole container is running
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - -f
+      - "{{ '{{.State.Running}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' }}"
+      - "{{ pihole_container_name | default('pihole') }}"
+  register: pihole_health
+  retries: 30
+  delay: 2
+  until:
+    - (pihole_health.stdout | default('', true) | trim).split()[0] == 'true'
+    - (pihole_health.stdout | default('', true) | trim).split()[1] | default('none') != 'unhealthy'
+  changed_when: false
+  when: pihole_unbound_present
+
+# Docker embedded DNS (127.0.0.11) resolves service names on user-defined networks; getent is unreliable in minimal images.
+- name: Verify Pi-hole can resolve Unbound via Docker embedded DNS
+  ansible.builtin.command: >
+    docker exec {{ pihole_container_name | default('pihole') }}
+    sh -lc 'dig +short {{ unbound_container_name | default("unbound") }} @127.0.0.11 +tries=2 +time=3'
+  register: pihole_resolve_unbound
+  changed_when: false
+  failed_when: >
+    (pihole_resolve_unbound.stdout_lines
+      | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+      | list
+      | length) == 0
+  when:
+    - pihole_unbound_present
+    - pihole_unbound_dns_target == (unbound_container_name | default('unbound'))
+
+- name: Verify Unbound answers DNS queries (from Pi-hole container)
+  ansible.builtin.command: >
+    docker exec {{ pihole_container_name | default('pihole') }}
+    sh -lc "dig @{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }} -p {{ unbound_port | default(5335) }} {{ pihole_unbound_verify_qname }} +short"
+  register: unbound_dns_test
+  changed_when: false
+  failed_when: >
+    (unbound_dns_test.stdout_lines
+      | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+      | list
+      | length) == 0
+  when: pihole_unbound_present
+
+- name: Verify Pi-hole answers DNS queries (through its local DNS)
+  ansible.builtin.command: >
+    docker exec {{ pihole_container_name | default('pihole') }}
+    sh -lc "dig @127.0.0.1 -p 53 {{ pihole_unbound_verify_qname }} +short +tries=1 +time=2"
+  register: pihole_dns_test
+  retries: 60
+  delay: 2
+  until: >
+    (pihole_dns_test.stdout_lines
+      | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+      | list
+      | length) > 0
+  changed_when: false
+  failed_when: >
+    (pihole_dns_test.stdout_lines
+      | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+      | list
+      | length) == 0
+  when: pihole_unbound_present

--- a/roles/pihole/tasks/unbound.yml
+++ b/roles/pihole/tasks/unbound.yml
@@ -78,12 +78,19 @@
   when: pihole_unbound_present and dns_net_inspect.rc != 0
 
 - name: Enable Pi-hole upstream to Unbound (set env vars)
+  vars:
+    _pihole_ftl_dns_upstreams: >-
+      {{
+        (pihole_unbound_dns_target | default(unbound_container_name | default('unbound')))
+        ~ '#'
+        ~ (unbound_port | default(5335) | string)
+      }}
   ansible.builtin.set_fact:
     pihole_environment_variables: >-
       {{
         (pihole_environment_variables | default({}))
         | combine({
-            'FTLCONF_dns_upstreams': ((pihole_unbound_dns_target | default(unbound_container_name | default('unbound'))) ~ '#' ~ (unbound_port | default(5335) | string)),
+            'FTLCONF_dns_upstreams': _pihole_ftl_dns_upstreams,
             'FTLCONF_dns_listeningMode': 'all'
           }, recursive=True)
       }}
@@ -269,9 +276,12 @@
     - pihole_unbound_dns_target == (unbound_container_name | default('unbound'))
 
 - name: Verify Unbound answers DNS queries (from Pi-hole container)
+  vars:
+    _pihole_unbound_dig_target: >-
+      {{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}
   ansible.builtin.command: >
     docker exec {{ pihole_container_name | default('pihole') }}
-    sh -lc "dig @{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }} -p {{ unbound_port | default(5335) }} {{ pihole_unbound_verify_qname }} +short"
+    sh -lc "dig @{{ _pihole_unbound_dig_target }} -p {{ unbound_port | default(5335) }} {{ pihole_unbound_verify_qname }} +short"
   register: unbound_dns_test
   changed_when: false
   failed_when: >

--- a/roles/pihole/tasks/verify.yml
+++ b/roles/pihole/tasks/verify.yml
@@ -1,0 +1,32 @@
+---
+- name: Check if Pi-hole container is running
+  ansible.builtin.command: docker ps --filter "name={{ pihole_container_name }}" --format "{{ '{{' }}.Names{{ '}}' }}"
+  register: pihole_status
+  changed_when: false
+  failed_when: pihole_status.rc != 0
+
+- name: Assert Pi-hole container is running
+  ansible.builtin.assert:
+    that:
+      - pihole_status.stdout_lines | length > 0
+    fail_msg: "Pi-hole container is not running."
+    success_msg: "Pi-hole container is running."
+
+- name: DNS test for google.com via local Pi-hole
+  ansible.builtin.command:
+    cmd: dig +short google.com @127.0.0.1 +timeout=3 +tries=2
+  register: dns_test_google
+  changed_when: false
+  failed_when: false
+  retries: 18
+  delay: 5
+  until: (dns_test_google.rc | default(1)) == 0 and (dns_test_google.stdout | default('') | trim | length > 0)
+
+- name: Assert google.com result looks like valid IPv4
+  ansible.builtin.assert:
+    that:
+      - dns_test_google.stdout_lines | length > 0
+      - dns_test_google.stdout_lines | select(
+          'match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$'
+        ) | list | length > 0
+    fail_msg: "DNS did not return at least one valid IPv4 for google.com via Pi-hole:\n{{ dns_test_google.stdout }}"

--- a/roles/pihole/templates/docker-compose.yml.j2
+++ b/roles/pihole/templates/docker-compose.yml.j2
@@ -1,0 +1,56 @@
+---
+{% if (not (pihole_use_host_network | default(false) | bool)) and (pihole_network_name is defined and pihole_network_name | string | length > 0) %}
+networks:
+  {{ pihole_network_name }}:
+    external: true
+
+{% endif %}
+services:
+
+  pihole:
+    container_name: {{ pihole_container_name }}
+    hostname: {{ inventory_hostname }}
+    image: {{ pihole_image }}
+    restart: unless-stopped
+{% if pihole_use_host_network | default(false) | bool %}
+    network_mode: host
+{% endif %}
+    environment:
+{% for var, value in pihole_environment_variables.items() %}
+      - {{ var }}={{ value }}
+{% endfor %}
+    volumes:
+      - {{ dir_loc }}/etc/pihole:/etc/pihole
+      - {{ dir_loc }}/etc/dnsmasq.d:/etc/dnsmasq.d
+    cap_add:
+      - NET_ADMIN
+      - SYS_TIME
+      - SYS_NICE
+      - CAP_NET_BIND_SERVICE
+      - CAP_NET_RAW
+      - CAP_CHOWN
+{% if pihole_rocky_network_debug | default(false) | bool %}
+    privileged: true
+    security_opt:
+      - seccomp=unconfined
+      - label=disable
+{% endif %}
+{% if pihole_docker_dns | default([]) | length > 0 %}
+    dns:
+{% for ns in pihole_docker_dns %}
+      - {{ ns }}
+{% endfor %}
+{% endif %}
+{% if not (pihole_use_host_network | default(false) | bool) %}
+{% if pihole_network_name is defined and pihole_network_name | string | length > 0 %}
+    networks:
+      - {{ pihole_network_name }}
+{% endif %}
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "{{ webport_http }}:80/tcp"
+      - "{{ webport_https }}:443/tcp"{% if pihole_environment_variables.DHCP_ACTIVE | lower == 'true' %}
+      - "67:67/udp"  # DHCP port
+      {% endif %}
+{% endif %}

--- a/roles/pihole/vars/main.yml
+++ b/roles/pihole/vars/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT-0
+---
+# vars file for docker-pihole
+vars_pihole_environment_variables:
+  TZ: "UTC"

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,6 +1,0 @@
----
-# Pi-hole role from Galaxy (steveyminecraft.docker-pihole, v1.0.0+).
-roles:
-  - name: pihole
-    src: steveyminecraft.docker-pihole
-    version: v1.0.0

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -1,0 +1,5 @@
+# sshd
+
+Harden and configure OpenSSH server settings on Pi-hole hosts.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/start_keepalived/README.md
+++ b/roles/start_keepalived/README.md
@@ -1,0 +1,5 @@
+# start_keepalived
+
+Start keepalived after maintenance or Pi-hole updates.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/stop_keepalived/README.md
+++ b/roles/stop_keepalived/README.md
@@ -1,0 +1,5 @@
+# stop_keepalived
+
+Stop keepalived before maintenance or Pi-hole updates.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/roles/updates/README.md
+++ b/roles/updates/README.md
@@ -1,0 +1,5 @@
+# updates
+
+Apply OS package updates on Pi-hole hosts.
+
+Part of the `steveyminecraft.pihole` collection.

--- a/scripts/install-ansible-collections.sh
+++ b/scripts/install-ansible-collections.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install Galaxy roles and collections for this repo.
+# Install this collection and third-party collections for local dev / CI.
 # ansible.posix is installed from git (PR #690) via CLI so ansible-galaxy does not mix git refs
 # with semver resolution in a single requirements file (avoids LooseVersion errors with SHAs).
 set -euo pipefail
@@ -10,29 +10,10 @@ cd "$ROOT"
 COL="${ANSIBLE_COLLECTIONS_INSTALL_PATH:-$ROOT/.ansible/collections}"
 mkdir -p "$COL"
 
-if [[ -f "$ROOT/roles/requirements.yml" ]]; then
-  ansible-galaxy role install -r "$ROOT/roles/requirements.yml" -p "$ROOT/roles"
-fi
-
-PIHOLE_NAT_TASKS="$ROOT/roles/pihole/tasks/redhat_nat_fallback.yml"
-if [[ -f "$PIHOLE_NAT_TASKS" ]] && ! grep -q "Add nftables masquerade rules per Docker subnet" "$PIHOLE_NAT_TASKS"; then
-  # Python, not patch(1): older GNU patch (e.g. Ubuntu 22.04 CI) rejects some valid unified hunks.
-  python3 "$ROOT/scripts/apply_pihole_redhat_nat_fallback.py" "$PIHOLE_NAT_TASKS"
-fi
-
-PIHOLE_UNBOUND_TASKS="$ROOT/roles/pihole/tasks/unbound.yml"
-if [[ -f "$PIHOLE_UNBOUND_TASKS" ]] && grep -q "Wait until Pi-hole is healthy" "$PIHOLE_UNBOUND_TASKS"; then
-  python3 "$ROOT/scripts/apply_pihole_unbound_health_wait.py" "$PIHOLE_UNBOUND_TASKS"
-fi
-
-PIHOLE_DEFAULTS="$ROOT/roles/pihole/defaults/main.yml"
-if [[ -f "$PIHOLE_DEFAULTS" ]] && grep -q "Public DNS first" "$PIHOLE_DEFAULTS"; then
-  python3 "$ROOT/scripts/apply_pihole_galaxy_install_overrides.py" defaults "$PIHOLE_DEFAULTS"
-fi
-
-if [[ -f "$PIHOLE_UNBOUND_TASKS" ]]; then
-  python3 "$ROOT/scripts/apply_pihole_galaxy_install_overrides.py" unbound "$PIHOLE_UNBOUND_TASKS"
-fi
+# Install steveyminecraft.pihole from a local build of this repository.
+ansible-galaxy collection build --force
+artifact="$(ls -1 steveyminecraft-pihole-*.tar.gz | head -1)"
+ansible-galaxy collection install "${artifact}" -p "$COL" --force
 
 # Pinned merge commit from https://github.com/ansible-collections/ansible.posix/pull/690
 ansible-galaxy collection install \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,0 @@
----
-- name: Ansible-pihole is a playbook repository
-  ansible.builtin.fail:
-    msg: >-
-      This Galaxy role only declares dependencies. Clone
-      https://github.com/steveyminecraft/ansible-pihole and run playbooks from
-      playbooks/ (for example playbooks/bootstrap-pihole.yaml).


### PR DESCRIPTION
## Summary

- Repackages ansible-pihole and docker-pihole as a single Ansible collection **`steveyminecraft.pihole`** (`galaxy.yml`, `meta/runtime.yml`).
- Vendors the Pi-hole Docker role into `roles/pihole/` with ansible-pihole compatibility changes applied in-tree (no post-install Galaxy patching).
- Updates playbooks to FQCN roles (`steveyminecraft.pihole.*`) and replaces legacy Galaxy role import workflows with collection **build**, **validate** (`galaxy-importer`), and **publish** on release tags.
- Adds role README files required by Galaxy collection import.

## Test plan

- [ ] CI lint job builds the collection artifact and passes `galaxy-importer`
- [ ] CI syntax-checks playbooks after `./scripts/install-ansible-collections.sh`
- [ ] After merge to `master` and tag `v1.0.x`, confirm `GALAXY_API_KEY` publishes `steveyminecraft.pihole` on [galaxy.ansible.com](https://galaxy.ansible.com/ui/collections/)
- [ ] `ansible-galaxy collection install steveyminecraft.pihole` resolves roles and playbooks

## Notes

- Legacy Galaxy roles `steveyminecraft.ansible-pihole` and `steveyminecraft.docker-pihole` are superseded; README documents migration.
- Release workflow syncs `galaxy.yml` `version` from the git tag before publish.


Made with [Cursor](https://cursor.com)