### PR TITLE
chore(deps): bump ansible-core floor to >=2.20.5

### DIFF
--- a/.github/actions/import-galaxy-role/action.yml
+++ b/.github/actions/import-galaxy-role/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Install Ansible
       shell: bash
-      run: python -m pip install 'ansible-core>=2.20,<2.21'
+      run: python -m pip install 'ansible-core>=2.20.5,<2.21'
 
     - name: Import role into Ansible Galaxy
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.20,<2.21' ansible-lint yamllint galaxy-importer
+          python -m pip install --upgrade 'ansible-core>=2.20.5,<2.21' ansible-lint yamllint galaxy-importer
 
       - name: Build and validate collection for Ansible Galaxy
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.20,<2.21'
+          python -m pip install --upgrade 'ansible-core>=2.20.5,<2.21'
 
       - name: Show Ansible version
         run: ansible --version

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Ansible and galaxy-importer
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.20,<2.21' galaxy-importer
+          python -m pip install --upgrade 'ansible-core>=2.20.5,<2.21' galaxy-importer
 
       - name: Build collection artifact
         run: ansible-galaxy collection build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
         run: |
-          python -m pip install --upgrade pip 'ansible-core>=2.20,<2.21' pyyaml
+          python -m pip install --upgrade pip 'ansible-core>=2.20.5,<2.21' pyyaml
           ansible-galaxy collection build
           if [ -z "${GALAXY_API_KEY:-}" ]; then
             echo "GALAXY_API_KEY is not set; skipping Galaxy publish."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-# Mirror CI: Python 3.13/3.14 + ansible-core 2.20.x (.github/workflows/ci.yml).
+# Mirror CI: Python 3.13/3.14 + ansible-core 2.20.5+ (.github/workflows/ci.yml). Stay on 2.20.x until 2.21 migration.
 repos:
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Controller toolchain (Python 3.13 or 3.14). CI tests both in .github/workflows/ci.yml.
-ansible-core>=2.20,<2.21
+ansible-core>=2.20.5,<2.21
 ansible-lint>=26.4.0
 yamllint>=1.38.0
 molecule>=26.4.0


### PR DESCRIPTION
## Summary

Applies [Dependabot #61](https://github.com/steveyminecraft/ansible-pihole/pull/61): raise the **ansible-core** minimum to **>=2.20.5** while staying on the **2.20.x** line (`<2.21`).

Updated consistently in:

- `requirements.txt`
- `.github/workflows/ci.yml`
- `.github/workflows/galaxy-publish.yml`
- `.github/workflows/release.yml`
- `.github/actions/import-galaxy-role/action.yml`
- `.pre-commit-config.yaml` comment (hook already pins `ansible-core==2.20.5`)

### Dependabot #60 (pre-commit → 2.21.0)

**Not merged.** The project targets ansible-core **2.20.x** (`meta/runtime.yml`, CI, Galaxy). Bumping pre-commit to **2.21.0** would diverge from that constraint. Pre-commit remains on **2.20.5** until a dedicated 2.21 migration PR updates CI, runtime, and docs together.

Closes #61.

## Test plan

- [ ] CI lint and syntax-check jobs pass with `ansible-core>=2.20.5,<2.21`


Made with [Cursor](https://cursor.com)