### PR TITLE
fix(ci): valid release-please-action pin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@a69878a2a253376386eda562be8aeb9cd4a66d41 # v4.1.0
+        uses: googleapis/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Fixes the **Release** workflow failure on `master` after #64 merged:

```
Unable to resolve action googleapis/release-please-action@a69878a2...
```

Replaces with the correct **v4.1.0** commit SHA.

## After merge

Fast-forward `dev` → `master` (or hotfix merge) so release-please can run and open the first Release PR for Galaxy publish.


Made with [Cursor](https://cursor.com)