### PR TITLE
fix(ci): release-please-action SHA on master

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@a69878a2a253376386eda562be8aeb9cd4a66d41 # v4.1.0
+        uses: googleapis/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Promotes #65 to `master`: fixes the invalid `googleapis/release-please-action` pin so the Release workflow can run after #64.

Single-line change in `.github/workflows/release-please.yml`.

## After merge

- Release workflow should succeed on the next `master` push
- release-please can open a Release PR for Galaxy publish


Made with [Cursor](https://cursor.com)