### PR TITLE
chore(release): promote Phase 1 security hardening from dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ docker_install_kernel_modules_extra: false
 
 Pi-hole-related variables (e.g. `pihole_environment_variables`, `pihole_ha_mode`, `pihole_vip_ipv4` / `pihole_vip_ipv6`) are typically set in inventory; see the [docker-pi-hole environment docs](https://github.com/pi-hole/docker-pi-hole#environment-variables) for image variables.
 
+Security defaults:
+
+- `FTLCONF_webserver_api_password` must be provided from inventory/vault and should be at least 16 characters.
+- Known placeholders/defaults (`Testing 101`, `Intranet`, `CHANGE_ME`, empty value) are rejected by role assertions.
+- Pi-hole compose files are rendered with root-only permissions (`0600`) in both normal and Unbound integration paths.
+
 Unbound is deployed before Pi-hole and can be used as Pi-hole's upstream resolver over a shared Docker network. By default the Unbound role now chooses an image from `unbound_image_arch_map` using the target host architecture:
 
 ```yaml
@@ -100,7 +106,13 @@ pihole_environment_variables:
   FTLCONF_dns_listeningMode: "all"
 ```
 
-When Pi-hole talks to Unbound on the shared Docker network, `unbound_publish_to_host` can usually be `false`; publish Unbound only if you also want to query it directly from the host.
+When Pi-hole talks to Unbound on the shared Docker network, `unbound_publish_to_host` now defaults to `false`; publish Unbound only if you also want to query it directly from the host. If enabled, bind it explicitly (default loopback):
+
+```yaml
+unbound_publish_to_host: true
+unbound_publish_host_ip: "127.0.0.1"
+unbound_publish_host_port: 5335
+```
 
 ### `playbooks/update-pihole.yaml`
 
@@ -114,7 +126,7 @@ Deploy or adjust keepalived HA between Pi-hole instances. Priorities and VIPs ar
 
 Deploy [Nebula Sync](https://github.com/lovelaze/nebula-sync) via [`roles/nebula_sync`](roles/nebula_sync/tasks/main.yml). Override `nebula_sync_image_tag` in inventory if you do not want `latest`.
 
-Set `nebula_sync_use_secret_files: true` to write the Nebula Sync `PRIMARY` and `REPLICAS` values to rootless-readable files and mount them into the container as `PRIMARY_FILE` / `REPLICAS_FILE`. The role defaults ownership to UID/GID `1001`, matching the upstream container user.
+Nebula Sync now defaults `nebula_sync_use_secret_files: true` so `PRIMARY` and `REPLICAS` credentials are written to mounted secret files (`PRIMARY_FILE` / `REPLICAS_FILE`) instead of plain env values where possible. The role defaults ownership to UID/GID `1001`, matching the upstream container user, and rejects placeholder credentials by default.
 
 ### Playbook tags
 

--- a/inventory/vagrant.yml
+++ b/inventory/vagrant.yml
@@ -37,7 +37,8 @@ all:
     pihole_environment_variables:
       TZ: "{{ timezone }}"
       FTLCONF_MAXDBDAYS: "180"
-      FTLCONF_webserver_api_password: 'Intranet'  # example value, change it and better use ansible-vault
+      # LAB-ONLY fixture for local Vagrant/Molecule runs. Never reuse in production.
+      FTLCONF_webserver_api_password: 'LabOnly-Molecule-Pihole-Password!'
       FTLCONF_dns_listeningMode: "all"
       DHCP_ACTIVE: false
       REV_SERVER: false

--- a/roles/nebula_sync/defaults/main.yml
+++ b/roles/nebula_sync/defaults/main.yml
@@ -50,7 +50,7 @@ nebula_sync_env_filename: ".env"
 
 # Store PRIMARY/REPLICAS credentials in read-only files mounted into the container.
 # Nebula Sync runs as UID/GID 1001 by default, so the files must be readable by 1001.
-nebula_sync_use_secret_files: false
+nebula_sync_use_secret_files: true
 nebula_sync_secret_dir: "{{ nebula_sync_dir }}/secrets"
 nebula_sync_secret_container_dir: "/run/secrets"
 nebula_sync_secret_file_owner: "1001"

--- a/roles/nebula_sync/tasks/main.yml
+++ b/roles/nebula_sync/tasks/main.yml
@@ -1,4 +1,28 @@
 ---
+- name: Validate Nebula Sync primary endpoint and credentials
+  no_log: true
+  ansible.builtin.assert:
+    that:
+      - (nebula_sync_primary_url | string | length) > 0
+      - (nebula_sync_primary_password | string | length) > 0
+      - (nebula_sync_primary_password | string) not in ['CHANGE_ME', 'Intranet', 'Testing 101', '']
+    fail_msg: >-
+      Define non-placeholder Nebula Sync PRIMARY values in inventory/vault before deployment.
+
+- name: Validate Nebula Sync replicas endpoint and credentials
+  no_log: true
+  ansible.builtin.assert:
+    that:
+      - (nebula_sync_replicas | default([]) | length) > 0
+      - (nebula_sync_replicas | map(attribute='url') | map('string') | map('length') | min) > 0
+      - (nebula_sync_replicas | map(attribute='password') | map('string') | map('length') | min) > 0
+      - "'CHANGE_ME' not in (nebula_sync_replicas | map(attribute='password') | list)"
+      - "'' not in (nebula_sync_replicas | map(attribute='password') | list)"
+      - "'Intranet' not in (nebula_sync_replicas | map(attribute='password') | list)"
+      - "'Testing 101' not in (nebula_sync_replicas | map(attribute='password') | list)"
+    fail_msg: >-
+      Define non-placeholder Nebula Sync REPLICAS values in inventory/vault before deployment.
+
 - name: Ensure nebula-sync directory exists
   ansible.builtin.file:
     path: "{{ nebula_sync_dir }}"

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -33,8 +33,8 @@ pihole_configure_systemd_resolved: true
 pihole_environment_variables:
   # Set the appropriate timezone for your location (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g:
   TZ: 'Europe/London'
-  # Set a password to access the web interface. Not setting one will result in a random password being assigned
-  FTLCONF_webserver_api_password: 'Testing 101'
+  # Define in inventory/vault; role tasks assert minimum strength before deploy.
+  FTLCONF_webserver_api_password: ''
   # If using Docker's default `bridge` network setting the dns listening mode should be set to 'ALL'
   FTLCONF_dns_listeningMode: 'ALL'
   # controls if required port is opened

--- a/roles/pihole/tasks/deploypi.yml
+++ b/roles/pihole/tasks/deploypi.yml
@@ -2,18 +2,19 @@
 - name: Create pihole directory
   ansible.builtin.file:
     path: "{{ pihole_compose_dir }}"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+    owner: "root"
+    group: "root"
     state: directory
-    mode: '0755'
+    mode: '0750'
 
 - name: Deploy Docker Compose file
+  no_log: true
   ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: "{{ pihole_compose_dir }}/docker-compose.yml"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0644'
+    owner: "root"
+    group: "root"
+    mode: '0600'
   register: pihole_compose_template
 
 - name: Pull docker image

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -16,6 +16,17 @@
     firewall_deploy: "{{ pihole_firewall_deploy | bool }}"
   when: pihole_firewall_deploy is defined
 
+- name: Validate Pi-hole Web/API password is configured securely
+  no_log: true
+  ansible.builtin.assert:
+    that:
+      - pihole_environment_variables.FTLCONF_webserver_api_password is defined
+      - (pihole_environment_variables.FTLCONF_webserver_api_password | string | length) >= 16
+      - (pihole_environment_variables.FTLCONF_webserver_api_password | string) not in ['Testing 101', 'Intranet', 'CHANGE_ME', '']
+    fail_msg: >-
+      Define a non-default Pi-hole Web/API password (minimum 16 chars) in inventory/vault
+      before deploying Pi-hole.
+
 - name: Debian setup tasks
   ansible.builtin.include_tasks: debian.yml
   when: ansible_facts['distribution'] in ['Debian', 'Ubuntu']

--- a/roles/pihole/tasks/unbound.yml
+++ b/roles/pihole/tasks/unbound.yml
@@ -97,10 +97,13 @@
   when: pihole_unbound_present
 
 - name: Re-render docker-compose.yml for Pi-hole (with Unbound integration)
+  no_log: true
   ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: "{{ pihole_compose_file }}"
-    mode: "0644"
+    owner: "root"
+    group: "root"
+    mode: "0600"
   when: pihole_unbound_present
 
 - name: Apply compose changes (Pi-hole)

--- a/roles/unbound/README.md
+++ b/roles/unbound/README.md
@@ -4,9 +4,11 @@ Runs Unbound DNS resolver in Docker via Docker Compose v2.
 
 ## Variables
 
-- `unbound_compose_dir` (default `/opt/unbound-docker`)
+- `unbound_compose_dir` (default `/opt/unbound`)
 - `unbound_network_name` (default `dns_net`)
 - `unbound_publish_to_host` (default `false`)
+- `unbound_publish_host_ip` (default `127.0.0.1`)
+- `unbound_publish_host_port` (default `5335`)
 - `unbound_port` (default `5335`)
 
 ## Example
@@ -18,5 +20,7 @@ Runs Unbound DNS resolver in Docker via Docker Compose v2.
     - role: unbound_docker
       vars:
         unbound_publish_to_host: true
-        unbound_publish_host_ip: "0.0.0.0"
+        # Prefer loopback unless external host access is explicitly required.
+        unbound_publish_host_ip: "127.0.0.1"
         unbound_publish_host_port: 5335
+```

--- a/roles/unbound/defaults/main.yml
+++ b/roles/unbound/defaults/main.yml
@@ -28,7 +28,7 @@ unbound_interface: "0.0.0.0"
 unbound_port: 5335
 
 # Expose to host? (not required for Pi-hole integration, but you had it enabled)
-unbound_publish_to_host: true
+unbound_publish_to_host: false
 unbound_publish_host_ip: "127.0.0.1"
 unbound_publish_host_port: 5335
 

--- a/roles/unbound/templates/docker-compose.yml.j2
+++ b/roles/unbound/templates/docker-compose.yml.j2
@@ -15,8 +15,8 @@ services:
       - "{{ unbound_port | default(5335) }}/udp"
 {% if (unbound_publish_to_host | default(false) | bool) %}
     ports:
-      - "{{ unbound_publish_host_port | default(unbound_port | default(5335)) }}:{{ unbound_port | default(5335) }}/tcp"
-      - "{{ unbound_publish_host_port | default(unbound_port | default(5335)) }}:{{ unbound_port | default(5335) }}/udp"
+      - "{{ unbound_publish_host_ip | default('127.0.0.1') }}:{{ unbound_publish_host_port | default(unbound_port | default(5335)) }}:{{ unbound_port | default(5335) }}/tcp"
+      - "{{ unbound_publish_host_ip | default('127.0.0.1') }}:{{ unbound_publish_host_port | default(unbound_port | default(5335)) }}:{{ unbound_port | default(5335) }}/udp"
 {% endif %}
     volumes:
       - {{ unbound_compose_dir }}/unbound/unbound.conf:{{ unbound_directory }}/unbound.conf:ro


### PR DESCRIPTION
## Summary
- promote the merged Phase 1 security hardening from `dev` to `master`
- includes secure credential validation for Pi-hole and Nebula Sync plus root-only compose file permissions in Pi-hole deploy paths
- includes safer defaults for Unbound host publishing and docs updates for security/deployment behavior

## Test plan
- [x] Validated on the source PR: https://github.com/steveyminecraft/ansible-pihole/pull/70
- [x] `ansible-galaxy collection build --force`
- [x] `python -m galaxy_importer.main <built-tarball>`
- [x] `ansible-lint -p roles playbooks molecule` (existing repo warnings unchanged)
- [x] `yamllint roles playbooks molecule inventory`
- [x] CI inventory syntax/check validation playbooks
- [x] `molecule test -s ubuntu`

Made with [Cursor](https://cursor.com)