### PR TITLE
chore(release): promote dev to master after CI safety fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
         run: |
           ansible-playbook -i inventory/ci/ci.yml playbooks/ci-bootstrap.yaml --check
 
-  molecule-ubuntu:
-    name: Molecule ubuntu integration
+  ci-safety-checks:
+    name: Hosted CI safety checks
     runs-on: ubuntu-latest
     needs: ansible-tests-ubuntu
     if: github.event_name == 'pull_request'
@@ -125,18 +125,30 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install Molecule toolchain
+      - name: Install YAML tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install --upgrade yamllint
 
-      - name: Install collections
-        run: ./scripts/install-ansible-collections.sh
-
-      - name: Install Vagrant
+      - name: Validate workflow and project YAML formatting
         run: |
-          sudo apt-get update
-          sudo apt-get install -y vagrant
+          yamllint .github/workflows molecule inventory playbooks roles
 
-      - name: Molecule syntax-only (ubuntu scenario)
-        run: molecule syntax -s ubuntu
+      - name: Validate Molecule scenario file structure
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import yaml
+
+          required = {
+              "molecule/ubuntu/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
+              "molecule/default/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
+          }
+          for relpath, keys in required.items():
+              path = Path(relpath)
+              data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+              missing = [k for k in keys if k not in data]
+              if missing:
+                  raise SystemExit(f"{relpath} missing keys: {missing}")
+          print("Molecule scenario structure checks passed.")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,5 +133,10 @@ jobs:
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh
 
+      - name: Install Vagrant
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y vagrant
+
       - name: Molecule syntax-only (ubuntu scenario)
         run: molecule syntax -s ubuntu

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ The `ubuntu` Molecule scenario now includes an explicit `idempotence` step in
 - Molecule, Ansible, Vagrant, and **VirtualBox** or **libvirt** (`vagrant-libvirt`) as appropriate.
 - Run Molecule from the **repository root** so paths and inventory links resolve.
 - **Lint:** CI runs [ansible-lint](https://ansible-lint.readthedocs.io/) on `roles`, `playbooks`, and `molecule`; [yamllint](https://yamllint.readthedocs.io/) includes `molecule/`.
+- Full `molecule test` with Vagrant providers is intended for local or self-hosted
+  environments where Vagrant + provider support is guaranteed.
 
 ### Scenarios
 
@@ -240,7 +242,9 @@ echo 'some text' | ./scripts/word_analysis.py
 
 GitHub Actions workflow [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs lint (ansible-lint, yamllint), installs dependencies via [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh), and syntax-checks / check-modes selected playbooks against [`inventory/ci/`](inventory/ci/).
 
-CI also runs a lightweight Molecule `ubuntu` syntax job on pull requests.
+Hosted CI also runs lightweight safety checks for Molecule configuration files (YAML/schema
+sanity) that do not require Vagrant or a VM provider. Full Molecule Vagrant scenarios remain
+local/self-hosted validation steps.
 
 ## Operational docs
 


### PR DESCRIPTION
## Summary
- promote merged `dev` changes (including CI hosted-safe Molecule checks) to `master`
- keep full Molecule Vagrant integration testing as local/self-hosted responsibility

## Test plan
- [x] PR #76 checks passed and merged to `dev`
- [x] existing CI checks validated on source branch
- [x] promotion via standard `dev -> master` workflow

Made with [Cursor](https://cursor.com)