### PR TITLE
ci: promote hosted ARM64 workflow coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,12 @@ permissions:
 
 jobs:
   lint:
-    name: Ansible & YAML lint (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Ansible & YAML lint (${{ matrix.runner }} / Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
         python-version: ["3.13", "3.14"]
 
     steps:
@@ -65,12 +66,13 @@ jobs:
         run: yamllint roles playbooks molecule inventory
 
   ansible-tests-ubuntu:
-    name: Ansible syntax & dry-run (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Ansible syntax & dry-run (${{ matrix.runner }} / Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.runner }}
     needs: lint
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
         python-version: ["3.13", "3.14"]
 
     steps:
@@ -111,7 +113,7 @@ jobs:
 
   ci-safety-checks:
     name: Hosted CI safety checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: ansible-tests-ubuntu
     if: github.event_name == 'pull_request'
     steps:

--- a/README.md
+++ b/README.md
@@ -275,7 +275,11 @@ echo 'some text' | ./scripts/word_analysis.py
 
 ## CI
 
-GitHub Actions workflow [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs lint (ansible-lint, yamllint), installs dependencies via [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh), and syntax-checks / check-modes selected playbooks against [`inventory/ci/`](inventory/ci/).
+GitHub Actions workflow [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
+runs lint (ansible-lint, yamllint), installs dependencies via
+[`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh),
+and syntax-checks / check-modes selected playbooks against [`inventory/ci/`](inventory/ci/)
+on GitHub-hosted Ubuntu 24.04 x64 and ARM64 runners.
 
 Hosted CI also runs lightweight safety checks for Molecule configuration files (YAML/schema
 sanity) that do not require Vagrant or a VM provider. Full Molecule Vagrant scenarios remain


### PR DESCRIPTION
## Summary
- Promotes hosted Ubuntu 24.04 x64 and ARM64 CI coverage from `dev` to `master`.
- Documents that CI now runs lint and Ansible syntax/check-mode coverage on GitHub-hosted ARM64 runners.

## Test plan
- Topic PR #82 checks passed, including Ubuntu 24.04 ARM64 lint and syntax/check-mode jobs.
- `dev` push CI passed after merging #82.
- `dev` security scanning passed after merging #82.


Made with [Cursor](https://cursor.com)