### PR TITLE
chore: sync dev to master (remove word_analysis README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,16 +263,6 @@ For Vagrant/Molecule inventories (`vagrant_env: true`), the bootstrap role now
 skips rebooting after hostname file updates to avoid long guest-network waits
 during test runs.
 
-### `scripts/word_analysis.py`
-
-Small utility to count **total words**, **unique word types**, type–token ratio, and per-word frequencies from a text file or stdin:
-
-```bash
-./scripts/word_analysis.py path/to/file.txt
-echo 'some text' | ./scripts/word_analysis.py
-./scripts/word_analysis.py --json --sort alpha notes.md
-```
-
 ## CI
 
 GitHub Actions workflow [`.github/workflows/ci.yml`](.github/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- Promotes `dev` to `master`, including the docs cleanup that removes the mistaken `scripts/word_analysis.py` README section (PR #84).

## Test plan
- [x] CI passed on PR #84 before merge to `dev`

Made with [Cursor](https://cursor.com)