### PR TITLE
[codex] fix HA rolling safety and Nebula Sync verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,23 @@ pihole_startup_dns:
 
 Faster follow-up runs (updates + Pi-hole-focused changes).
 
-Both `bootstrap-pihole.yaml` and `update-pihole.yaml` include post-task DNS checks.
-When Unbound integration is enabled, the Unbound probe now runs from inside the
-Pi-hole container (`docker exec`) so Docker-network upstream names (for example
-`unbound`) are resolved in the same network context Pi-hole uses.
+Both `bootstrap-pihole.yaml` and `update-pihole.yaml` use `serial: 1` for HA
+nodes and keep the current node drained from keepalived VIP ownership until local
+Pi-hole DNS passes. When Unbound is actually deployed for the node, the Unbound
+probe runs from inside the Pi-hole container (`docker exec`) so Docker-network
+upstream names (for example `unbound`) are resolved in the same network context
+Pi-hole uses. After all nodes pass and rejoin, the playbooks verify DNS through
+the VIP.
+
+Pi-hole container recreation is driven by Compose/configuration changes or an
+explicit maintenance override:
+
+```yaml
+pihole_force_recreate: true
+```
+
+Docker NAT/firewall reconciliation for lab modes does not by itself force a
+Pi-hole application-container recreate.
 
 ### `playbooks/keepalived.yaml`
 

--- a/molecule/common/verify_ha.yml
+++ b/molecule/common/verify_ha.yml
@@ -10,6 +10,14 @@
     ha_container_name: "{{ pihole_container_name | default('pihole') }}"
     pihole_gravity_db: "{{ pihole_compose_dir | default('/opt/pihole') }}/etc/pihole/gravity.db"
     nebula_sync_test_list_url: "https://example.invalid/nebula-sync-test.txt"
+    nebula_sync_secret_host_dir: "{{ nebula_sync_secret_dir | default((nebula_sync_dir | default('/opt/nebula-sync')) ~ '/secrets') }}"
+    nebula_sync_env_host_path: >-
+      {{ (nebula_sync_dir | default('/opt/nebula-sync')) ~ '/' ~ (nebula_sync_env_filename | default('.env')) }}
+    nebula_sync_primary_secret_container_path: >-
+      {{ (nebula_sync_secret_container_dir | default('/run/secrets')) ~ '/' ~ (nebula_sync_primary_secret_filename | default('primary')) }}
+    nebula_sync_replicas_secret_container_path: >-
+      {{ (nebula_sync_secret_container_dir | default('/run/secrets')) ~ '/' ~ (nebula_sync_replicas_secret_filename | default('replicas')) }}
+    nebula_sync_mounts_fmt: "{{ '{{json .Mounts}}' }}"
   tasks:
     - name: Ensure node is reachable
       ansible.builtin.ping:
@@ -168,6 +176,7 @@
       when: nebula_sync_primary_url is defined
 
     - name: Read Nebula Sync container environment
+      no_log: true
       ansible.builtin.command:
         argv:
           - docker
@@ -179,78 +188,373 @@
       changed_when: false
       when: nebula_sync_primary_url is defined
 
-    - name: Assert Nebula Sync points at expected Pi-hole instances
-      ansible.builtin.assert:
-        that:
-          - ('PRIMARY=' ~ nebula_sync_primary_url ~ '|' ~ nebula_sync_primary_password) in nebula_sync_env.stdout_lines
-          - nebula_sync_replicas | length > 0
-          - nebula_sync_env.stdout_lines | select('search', '^REPLICAS=.*' ~ nebula_sync_replicas[0].url) | list | length > 0
-        fail_msg: "Nebula Sync PRIMARY/REPLICAS environment does not match inventory."
+    - name: Stat Nebula Sync env file
+      ansible.builtin.stat:
+        path: "{{ nebula_sync_env_host_path }}"
+      register: nebula_sync_env_file_stat
+      when:
+        - nebula_sync_primary_url is defined
+        - nebula_sync_use_env_file | default(true) | bool
+
+    - name: Read Nebula Sync env file
+      no_log: true
+      ansible.builtin.slurp:
+        src: "{{ nebula_sync_env_host_path }}"
+      register: nebula_sync_env_file
+      when:
+        - nebula_sync_primary_url is defined
+        - nebula_sync_use_env_file | default(true) | bool
+        - nebula_sync_env_file_stat.stat.exists | default(false)
+
+    - name: Set Nebula Sync effective environment lines
+      no_log: true
+      ansible.builtin.set_fact:
+        nebula_sync_effective_env_lines: >-
+          {{
+            (
+              (nebula_sync_env_file.content | b64decode).splitlines()
+              if (
+                (nebula_sync_use_env_file | default(true) | bool)
+                and (nebula_sync_env_file.content is defined)
+              )
+              else nebula_sync_env.stdout_lines
+            )
+          }}
       when: nebula_sync_primary_url is defined
 
-    - name: Create temporary gravity list entry on primary (Nebula Sync replication check)
-      ansible.builtin.command:
-        argv:
-          - sqlite3
-          - "{{ pihole_gravity_db }}"
-          - >-
-            INSERT OR IGNORE INTO adlist(address,enabled,comment)
-            VALUES ('{{ nebula_sync_test_list_url }}',1,'molecule-nebula-sync-test');
-      register: nebula_sync_test_insert
-      changed_when: true
-      when: inventory_hostname == node1 and nebula_sync_primary_url is defined
-
-    - name: Restart Nebula Sync container to trigger sync on primary
+    - name: Read Nebula Sync container mounts
+      no_log: true
       ansible.builtin.command:
         argv:
           - docker
-          - restart
+          - inspect
+          - --format
+          - "{{ nebula_sync_mounts_fmt }}"
           - "{{ nebula_sync_container_name | default('nebula') }}"
-      register: nebula_sync_test_run
-      changed_when: true
-      when: inventory_hostname == node1 and nebula_sync_primary_url is defined
-
-    - name: Wait for replicated gravity list entry on secondary
-      ansible.builtin.command:
-        argv:
-          - sqlite3
-          - "{{ pihole_gravity_db }}"
-          - >-
-            SELECT address FROM adlist
-            WHERE address='{{ nebula_sync_test_list_url }}';
-      register: nebula_sync_replica_lookup
+      register: nebula_sync_mounts
       changed_when: false
-      retries: 20
-      delay: 3
-      until: nebula_sync_test_list_url in nebula_sync_replica_lookup.stdout
-      when: inventory_hostname == node2 and nebula_sync_primary_url is defined
+      when: nebula_sync_primary_url is defined
 
-    - name: Assert Nebula Sync replicated the temporary entry to secondary
+    - name: Set Nebula Sync secret-file verification facts
+      no_log: true
+      ansible.builtin.set_fact:
+        nebula_sync_primary_file_configured: >-
+          {{
+            (('PRIMARY_FILE=' ~ nebula_sync_primary_secret_container_path) in nebula_sync_effective_env_lines)
+            or (('PRIMARY_FILE=' ~ nebula_sync_primary_secret_container_path) in nebula_sync_env.stdout_lines)
+          }}
+        nebula_sync_replicas_file_configured: >-
+          {{
+            (('REPLICAS_FILE=' ~ nebula_sync_replicas_secret_container_path) in nebula_sync_effective_env_lines)
+            or (('REPLICAS_FILE=' ~ nebula_sync_replicas_secret_container_path) in nebula_sync_env.stdout_lines)
+          }}
+        nebula_sync_plaintext_primary_present: >-
+          {{
+            ((nebula_sync_effective_env_lines | select('search', '^PRIMARY=.*\\|') | list | length) > 0)
+            or ((nebula_sync_env.stdout_lines | select('search', '^PRIMARY=.*\\|') | list | length) > 0)
+          }}
+        nebula_sync_plaintext_replicas_present: >-
+          {{
+            ((nebula_sync_effective_env_lines | select('search', '^REPLICAS=.*\\|') | list | length) > 0)
+            or ((nebula_sync_env.stdout_lines | select('search', '^REPLICAS=.*\\|') | list | length) > 0)
+          }}
+        nebula_sync_mounted_secret_destinations: >-
+          {{
+            (nebula_sync_mounts.stdout | from_json)
+            | map(attribute='Destination')
+            | list
+          }}
+      when: nebula_sync_primary_url is defined
+
+    - name: Determine whether Nebula Sync secure-mode remediation is needed
+      ansible.builtin.set_fact:
+        nebula_sync_secret_mode_remediation_needed: >-
+          {{
+            (nebula_sync_use_secret_files | default(true) | bool)
+            and (
+              not (nebula_sync_primary_file_configured | bool)
+              or not (nebula_sync_replicas_file_configured | bool)
+              or (nebula_sync_plaintext_primary_present | bool)
+              or (nebula_sync_plaintext_replicas_present | bool)
+              or nebula_sync_primary_secret_container_path not in nebula_sync_mounted_secret_destinations
+              or nebula_sync_replicas_secret_container_path not in nebula_sync_mounted_secret_destinations
+            )
+          }}
+      when: nebula_sync_primary_url is defined
+
+    - name: Remediate legacy Nebula Sync plaintext container
+      when:
+        - nebula_sync_primary_url is defined
+        - nebula_sync_secret_mode_remediation_needed | default(false) | bool
+      block:
+        - name: Stop legacy Nebula Sync compose project before secure-mode remediation
+          ansible.builtin.command:
+            argv:
+              - docker
+              - compose
+              - -f
+              - "{{ nebula_compose_file | default(nebula_sync_dir | default('/opt/nebula-sync') ~ '/docker-compose.yml') }}"
+              - down
+              - --remove-orphans
+          args:
+            chdir: "{{ nebula_sync_dir | default('/opt/nebula-sync') }}"
+          register: nebula_sync_verify_compose_down
+          changed_when: true
+          failed_when: nebula_sync_verify_compose_down.rc != 0
+          when:
+            - (nebula_sync_plaintext_primary_present | bool)
+              or (nebula_sync_plaintext_replicas_present | bool)
+
+        - name: Remove legacy Nebula Sync container before secure-mode remediation
+          community.docker.docker_container:
+            name: "{{ nebula_sync_container_name | default('nebula') }}"
+            state: absent
+          when:
+            - (nebula_sync_plaintext_primary_present | bool)
+              or (nebula_sync_plaintext_replicas_present | bool)
+
+        - name: Gather minimal facts for Nebula Sync role remediation
+          ansible.builtin.setup:
+            gather_subset:
+              - min
+
+        - name: Re-apply local Nebula Sync role in secret-file mode
+          ansible.builtin.include_role:
+            name: nebula_sync
+
+        - name: Re-read Nebula Sync container environment after remediation
+          no_log: true
+          ansible.builtin.command:
+            argv:
+              - docker
+              - inspect
+              - --format
+              - "{{ docker_inspect_env_fmt }}"
+              - "{{ nebula_sync_container_name | default('nebula') }}"
+          register: nebula_sync_env
+          changed_when: false
+
+        - name: Re-stat Nebula Sync env file after remediation
+          ansible.builtin.stat:
+            path: "{{ nebula_sync_env_host_path }}"
+          register: nebula_sync_env_file_stat
+          when: nebula_sync_use_env_file | default(true) | bool
+
+        - name: Re-read Nebula Sync env file after remediation
+          no_log: true
+          ansible.builtin.slurp:
+            src: "{{ nebula_sync_env_host_path }}"
+          register: nebula_sync_env_file
+          when:
+            - nebula_sync_use_env_file | default(true) | bool
+            - nebula_sync_env_file_stat.stat.exists | default(false)
+
+        - name: Rebuild Nebula Sync effective environment lines after remediation
+          no_log: true
+          ansible.builtin.set_fact:
+            nebula_sync_effective_env_lines: >-
+              {{
+                (
+                  (nebula_sync_env_file.content | b64decode).splitlines()
+                  if (
+                    (nebula_sync_use_env_file | default(true) | bool)
+                    and (nebula_sync_env_file.content is defined)
+                  )
+                  else nebula_sync_env.stdout_lines
+                )
+              }}
+
+        - name: Re-read Nebula Sync container mounts after remediation
+          no_log: true
+          ansible.builtin.command:
+            argv:
+              - docker
+              - inspect
+              - --format
+              - "{{ nebula_sync_mounts_fmt }}"
+              - "{{ nebula_sync_container_name | default('nebula') }}"
+          register: nebula_sync_mounts
+          changed_when: false
+
+        - name: Recompute Nebula Sync secret-file verification facts after remediation
+          no_log: true
+          ansible.builtin.set_fact:
+            nebula_sync_primary_file_configured: >-
+              {{
+                (('PRIMARY_FILE=' ~ nebula_sync_primary_secret_container_path) in nebula_sync_effective_env_lines)
+                or (('PRIMARY_FILE=' ~ nebula_sync_primary_secret_container_path) in nebula_sync_env.stdout_lines)
+              }}
+            nebula_sync_replicas_file_configured: >-
+              {{
+                (('REPLICAS_FILE=' ~ nebula_sync_replicas_secret_container_path) in nebula_sync_effective_env_lines)
+                or (('REPLICAS_FILE=' ~ nebula_sync_replicas_secret_container_path) in nebula_sync_env.stdout_lines)
+              }}
+            nebula_sync_plaintext_primary_present: >-
+              {{
+                ((nebula_sync_effective_env_lines | select('search', '^PRIMARY=.*\\|') | list | length) > 0)
+                or ((nebula_sync_env.stdout_lines | select('search', '^PRIMARY=.*\\|') | list | length) > 0)
+              }}
+            nebula_sync_plaintext_replicas_present: >-
+              {{
+                ((nebula_sync_effective_env_lines | select('search', '^REPLICAS=.*\\|') | list | length) > 0)
+                or ((nebula_sync_env.stdout_lines | select('search', '^REPLICAS=.*\\|') | list | length) > 0)
+              }}
+            nebula_sync_mounted_secret_destinations: >-
+              {{
+                (nebula_sync_mounts.stdout | from_json)
+                | map(attribute='Destination')
+                | list
+              }}
+
+    - name: Assert Nebula Sync uses secret-file credential configuration
       ansible.builtin.assert:
         that:
-          - nebula_sync_test_list_url in nebula_sync_replica_lookup.stdout
-        fail_msg: "Nebula Sync did not replicate temporary gravity entry to secondary node."
-      when: inventory_hostname == node2 and nebula_sync_primary_url is defined
+          - nebula_sync_use_secret_files | default(true) | bool
+          - nebula_sync_primary_file_configured | bool
+          - nebula_sync_replicas_file_configured | bool
+          - nebula_sync_primary_secret_container_path in nebula_sync_mounted_secret_destinations
+          - nebula_sync_replicas_secret_container_path in nebula_sync_mounted_secret_destinations
+        fail_msg: >-
+          Nebula Sync is not using secret-file mode as expected.
+          primary_file_configured={{ nebula_sync_primary_file_configured | default(false) }},
+          replicas_file_configured={{ nebula_sync_replicas_file_configured | default(false) }},
+          plaintext_primary_present={{ nebula_sync_plaintext_primary_present | default(false) }},
+          plaintext_replicas_present={{ nebula_sync_plaintext_replicas_present | default(false) }},
+          expected_primary_mount={{ nebula_sync_primary_secret_container_path }},
+          expected_replicas_mount={{ nebula_sync_replicas_secret_container_path }},
+          mounted_destinations={{ nebula_sync_mounted_secret_destinations | default([]) }}.
+      when: nebula_sync_primary_url is defined
 
-    - name: Remove temporary gravity list entry from primary
-      ansible.builtin.command:
-        argv:
-          - sqlite3
-          - "{{ pihole_gravity_db }}"
-          - >-
-            DELETE FROM adlist
-            WHERE address='{{ nebula_sync_test_list_url }}';
-      changed_when: true
-      when: inventory_hostname == node1 and nebula_sync_primary_url is defined
+    - name: Report legacy Nebula Sync plaintext environment if still present
+      ansible.builtin.debug:
+        msg: >-
+          Nebula Sync secret-file wiring is active, but Docker still reports
+          legacy plaintext PRIMARY/REPLICAS variables. This verifier does not
+          use those values; rerun converge or recreate the Nebula Sync compose
+          project to remove stale container environment metadata.
+      when:
+        - nebula_sync_primary_url is defined
+        - (nebula_sync_plaintext_primary_present | bool)
+          or (nebula_sync_plaintext_replicas_present | bool)
 
-    - name: Restart Nebula Sync container to propagate cleanup
-      ansible.builtin.command:
-        argv:
-          - docker
-          - restart
-          - "{{ nebula_sync_container_name | default('nebula') }}"
-      changed_when: true
-      when: inventory_hostname == node1 and nebula_sync_primary_url is defined
+    - name: Stat Nebula Sync primary secret file
+      ansible.builtin.stat:
+        path: "{{ nebula_sync_secret_host_dir }}/{{ nebula_sync_primary_secret_filename | default('primary') }}"
+      register: nebula_sync_primary_secret_stat
+      when: nebula_sync_primary_url is defined
+
+    - name: Stat Nebula Sync replicas secret file
+      ansible.builtin.stat:
+        path: "{{ nebula_sync_secret_host_dir }}/{{ nebula_sync_replicas_secret_filename | default('replicas') }}"
+      register: nebula_sync_replicas_secret_stat
+      when: nebula_sync_primary_url is defined
+
+    - name: Assert Nebula Sync secret files are restrictive
+      ansible.builtin.assert:
+        that:
+          - nebula_sync_primary_secret_stat.stat.exists | default(false)
+          - nebula_sync_replicas_secret_stat.stat.exists | default(false)
+          - nebula_sync_primary_secret_stat.stat.mode == '0400'
+          - nebula_sync_replicas_secret_stat.stat.mode == '0400'
+        fail_msg: "Nebula Sync secret files are missing or not mode 0400."
+      when: nebula_sync_primary_url is defined
+
+    - name: Verify Nebula Sync replicates Pi-hole configuration
+      when: nebula_sync_primary_url is defined
+      block:
+        - name: Create temporary gravity list entry on primary
+          ansible.builtin.command:
+            argv:
+              - sqlite3
+              - "{{ pihole_gravity_db }}"
+              - >-
+                INSERT OR IGNORE INTO adlist(address,enabled,comment)
+                VALUES ('{{ nebula_sync_test_list_url }}',1,'molecule-nebula-sync-test');
+          register: nebula_sync_test_insert
+          changed_when: true
+          when: inventory_hostname == node1
+
+        - name: Restart Nebula Sync container to trigger sync on primary
+          ansible.builtin.command:
+            argv:
+              - docker
+              - restart
+              - "{{ nebula_sync_container_name | default('nebula') }}"
+          register: nebula_sync_test_run
+          changed_when: true
+          when: inventory_hostname == node1
+
+        - name: Wait for replicated gravity list entry on secondary
+          ansible.builtin.command:
+            argv:
+              - sqlite3
+              - "{{ pihole_gravity_db }}"
+              - >-
+                SELECT address FROM adlist
+                WHERE address='{{ nebula_sync_test_list_url }}';
+          register: nebula_sync_replica_lookup
+          changed_when: false
+          retries: 20
+          delay: 3
+          until: nebula_sync_test_list_url in nebula_sync_replica_lookup.stdout
+          when: inventory_hostname == node2
+
+        - name: Assert Nebula Sync replicated the temporary entry to secondary
+          ansible.builtin.assert:
+            that:
+              - nebula_sync_test_list_url in nebula_sync_replica_lookup.stdout
+            fail_msg: "Nebula Sync did not replicate temporary gravity entry to secondary node."
+          when: inventory_hostname == node2
+
+      always:
+        - name: Remove temporary gravity list entry from primary
+          ansible.builtin.command:
+            argv:
+              - sqlite3
+              - "{{ pihole_gravity_db }}"
+              - >-
+                DELETE FROM adlist
+                WHERE address='{{ nebula_sync_test_list_url }}';
+          changed_when: true
+          when: inventory_hostname == node1
+
+        - name: Restart Nebula Sync container to propagate cleanup
+          ansible.builtin.command:
+            argv:
+              - docker
+              - restart
+              - "{{ nebula_sync_container_name | default('nebula') }}"
+          changed_when: true
+          when: inventory_hostname == node1
+
+        - name: Wait for temporary gravity list entry removal on secondary
+          ansible.builtin.command:
+            argv:
+              - sqlite3
+              - "{{ pihole_gravity_db }}"
+              - >-
+                SELECT address FROM adlist
+                WHERE address='{{ nebula_sync_test_list_url }}';
+          register: nebula_sync_replica_cleanup_lookup
+          changed_when: false
+          failed_when: false
+          retries: 20
+          delay: 3
+          until: nebula_sync_test_list_url not in nebula_sync_replica_cleanup_lookup.stdout
+          when: inventory_hostname == node2
+
+        - name: Remove temporary gravity list entry from secondary as last-resort cleanup
+          ansible.builtin.command:
+            argv:
+              - sqlite3
+              - "{{ pihole_gravity_db }}"
+              - >-
+                DELETE FROM adlist
+                WHERE address='{{ nebula_sync_test_list_url }}';
+          changed_when: true
+          when:
+            - inventory_hostname == node2
+            - nebula_sync_test_list_url in (nebula_sync_replica_cleanup_lookup.stdout | default(''))
 
     # --- Docker container stop triggers VIP move ---
     - name: Check HA container on primary before docker failover test
@@ -316,6 +620,7 @@
       ansible.builtin.command: docker exec {{ ha_container_name }} sh -lc "pkill -f pihole-FTL || true"
       register: pihole_dns_stop_primary
       changed_when: true
+      failed_when: pihole_dns_stop_primary.rc not in [0, 137, 143]
       when: inventory_hostname == node1
 
     - name: Wait for VIP on backup after functional DNS failure

--- a/playbooks/bootstrap-pihole.yaml
+++ b/playbooks/bootstrap-pihole.yaml
@@ -3,8 +3,10 @@
   hosts: all
   become: true
   serial: 1
+  any_errors_fatal: true
   vars:
     pihole_bootstrap_health_qname: "{{ pihole_unbound_verify_qname | default('google.com') }}"
+    keepalived_defer_service_restart: true
   roles:
     - role: steveyminecraft.pihole.stop_keepalived
       tags: [stopkeepalived, drain, ha]
@@ -22,48 +24,82 @@
       tags: [unbound, dns]
     - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
-    - role: steveyminecraft.pihole.start_keepalived
-      tags: [startkeepalived, resume, ha]
   post_tasks:
-    - name: Wait for local Pi-hole DNS listener
-      ansible.builtin.wait_for:
-        host: 127.0.0.1
-        port: 53
-        timeout: 180
-        delay: 2
+    - name: Validate node DNS before resuming keepalived
       tags: [pihole, dns, ha]
+      block:
+        - name: Wait for local Pi-hole DNS listener
+          ansible.builtin.wait_for:
+            host: 127.0.0.1
+            port: 53
+            timeout: 180
+            delay: 2
 
-    - name: Verify local Pi-hole DNS resolves health qname
+        - name: Verify local Pi-hole DNS resolves health qname
+          ansible.builtin.command:
+            argv:
+              - dig
+              - +short
+              - "@127.0.0.1"
+              - "{{ pihole_bootstrap_health_qname }}"
+          register: pihole_bootstrap_local_dns
+          changed_when: false
+          failed_when: >
+            (pihole_bootstrap_local_dns.stdout_lines
+             | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+             | list | length) == 0
+
+        - name: Verify local Unbound DNS when deployed
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - "{{ pihole_container_name | default('pihole') }}"
+              - sh
+              - -lc
+              - >-
+                dig +short @{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}
+                -p {{ unbound_port | default(5335) | string }} {{ pihole_bootstrap_health_qname }}
+          register: pihole_bootstrap_unbound_dns
+          changed_when: false
+          failed_when: >
+            (pihole_bootstrap_unbound_dns.stdout_lines
+             | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+             | list | length) == 0
+          when: pihole_unbound_present | default(false) | bool
+
+        - name: Resume keepalived after local DNS validation
+          ansible.builtin.include_role:
+            name: steveyminecraft.pihole.start_keepalived
+
+      rescue:
+        - name: Stop bootstrap because node failed DNS validation while drained
+          ansible.builtin.fail:
+            msg: >-
+              {{ inventory_hostname }} failed post-bootstrap DNS validation.
+              Keepalived has not been resumed on this node. Repair the node
+              and verify DNS before returning it to VIP service.
+
+- name: Verify HA DNS after bootstrap
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Verify VIP DNS resolves health qname after bootstrap
       ansible.builtin.command:
         argv:
           - dig
           - +short
-          - "@127.0.0.1"
-          - "{{ pihole_bootstrap_health_qname }}"
-      register: pihole_bootstrap_local_dns
+          - "@{{ (pihole_vip_ipv4 | split('/'))[0] }}"
+          - "{{ pihole_bootstrap_health_qname | default(pihole_unbound_verify_qname | default('google.com')) }}"
+      register: pihole_bootstrap_vip_dns
       changed_when: false
       failed_when: >
-        (pihole_bootstrap_local_dns.stdout_lines
+        (pihole_bootstrap_vip_dns.stdout_lines
          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
          | list | length) == 0
-      tags: [pihole, dns, ha]
-
-    - name: Verify local Unbound DNS when enabled
-      ansible.builtin.command:
-        argv:
-          - docker
-          - exec
-          - "{{ pihole_container_name | default('pihole') }}"
-          - sh
-          - -lc
-          - >-
-            dig +short @{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}
-            -p {{ unbound_port | default(5335) | string }} {{ pihole_bootstrap_health_qname }}
-      register: pihole_bootstrap_unbound_dns
-      changed_when: false
-      failed_when: >
-        (pihole_bootstrap_unbound_dns.stdout_lines
-         | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
-         | list | length) == 0
-      when: not (pihole_use_host_network | default(false) | bool)
+      run_once: true
+      when:
+        - pihole_ha_mode | default(false) | bool
+        - pihole_vip_ipv4 is defined
       tags: [pihole, dns, ha]

--- a/playbooks/update-pihole.yaml
+++ b/playbooks/update-pihole.yaml
@@ -3,6 +3,7 @@
   hosts: all
   become: true
   serial: 1
+  any_errors_fatal: true
   vars:
     pihole_update_health_qname: "{{ pihole_unbound_verify_qname | default('google.com') }}"
   roles:
@@ -12,48 +13,82 @@
       tags: [updates, system]
     - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
-    - role: steveyminecraft.pihole.start_keepalived
-      tags: [startkeepalived, resume, ha]
   post_tasks:
-    - name: Wait for local Pi-hole DNS listener
-      ansible.builtin.wait_for:
-        host: 127.0.0.1
-        port: 53
-        timeout: 180
-        delay: 2
+    - name: Validate node DNS before resuming keepalived
       tags: [pihole, dns, ha]
+      block:
+        - name: Wait for local Pi-hole DNS listener
+          ansible.builtin.wait_for:
+            host: 127.0.0.1
+            port: 53
+            timeout: 180
+            delay: 2
 
-    - name: Verify local Pi-hole DNS resolves health qname
+        - name: Verify local Pi-hole DNS resolves health qname
+          ansible.builtin.command:
+            argv:
+              - dig
+              - +short
+              - "@127.0.0.1"
+              - "{{ pihole_update_health_qname }}"
+          register: pihole_update_local_dns
+          changed_when: false
+          failed_when: >
+            (pihole_update_local_dns.stdout_lines
+             | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+             | list | length) == 0
+
+        - name: Verify local Unbound DNS when deployed
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - "{{ pihole_container_name | default('pihole') }}"
+              - sh
+              - -lc
+              - >-
+                dig +short @{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}
+                -p {{ unbound_port | default(5335) | string }} {{ pihole_update_health_qname }}
+          register: pihole_update_unbound_dns
+          changed_when: false
+          failed_when: >
+            (pihole_update_unbound_dns.stdout_lines
+             | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
+             | list | length) == 0
+          when: pihole_unbound_present | default(false) | bool
+
+        - name: Resume keepalived after local DNS validation
+          ansible.builtin.include_role:
+            name: steveyminecraft.pihole.start_keepalived
+
+      rescue:
+        - name: Stop update because node failed DNS validation while drained
+          ansible.builtin.fail:
+            msg: >-
+              {{ inventory_hostname }} failed post-update DNS validation.
+              Keepalived has not been resumed on this node. Repair the node
+              and verify DNS before returning it to VIP service.
+
+- name: Verify HA DNS after update
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Verify VIP DNS resolves health qname after update
       ansible.builtin.command:
         argv:
           - dig
           - +short
-          - "@127.0.0.1"
-          - "{{ pihole_update_health_qname }}"
-      register: pihole_update_local_dns
+          - "@{{ (pihole_vip_ipv4 | split('/'))[0] }}"
+          - "{{ pihole_update_health_qname | default(pihole_unbound_verify_qname | default('google.com')) }}"
+      register: pihole_update_vip_dns
       changed_when: false
       failed_when: >
-        (pihole_update_local_dns.stdout_lines
+        (pihole_update_vip_dns.stdout_lines
          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
          | list | length) == 0
-      tags: [pihole, dns, ha]
-
-    - name: Verify local Unbound DNS when enabled
-      ansible.builtin.command:
-        argv:
-          - docker
-          - exec
-          - "{{ pihole_container_name | default('pihole') }}"
-          - sh
-          - -lc
-          - >-
-            dig +short @{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}
-            -p {{ unbound_port | default(5335) | string }} {{ pihole_update_health_qname }}
-      register: pihole_update_unbound_dns
-      changed_when: false
-      failed_when: >
-        (pihole_update_unbound_dns.stdout_lines
-         | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
-         | list | length) == 0
-      when: not (pihole_use_host_network | default(false) | bool)
+      run_once: true
+      when:
+        - pihole_ha_mode | default(false) | bool
+        - pihole_vip_ipv4 is defined
       tags: [pihole, dns, ha]

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -15,6 +15,7 @@
 
 - name: Flush handlers
   meta: flush_handlers
+  when: not (keepalived_defer_service_restart | default(false) | bool)
 
 - name: Install keepalived Debian
   ansible.builtin.apt:
@@ -47,6 +48,13 @@
     state: stopped
     enabled: true
   when: ansible_facts['os_family'] == 'RedHat'
+
+- name: Keep keepalived drained while service restart is deferred
+  ansible.builtin.service:
+    name: keepalived
+    state: stopped
+    enabled: true
+  when: keepalived_defer_service_restart | default(false) | bool
 
 - name: Copy check_pihole.sh
   copy:
@@ -121,3 +129,4 @@
 
 - name: Flush handlers
   meta: flush_handlers
+  when: not (keepalived_defer_service_restart | default(false) | bool)

--- a/roles/nebula_sync/tasks/main.yml
+++ b/roles/nebula_sync/tasks/main.yml
@@ -88,6 +88,77 @@
     name: "{{ nebula_sync_image }}:{{ nebula_sync_image_tag }}"
     platform: "{{ ansible_facts['architecture'] }}"
 
+- name: Set Nebula Sync Docker inspect formats
+  ansible.builtin.set_fact:
+    nebula_sync_inspect_env_fmt: "{{ '{{range .Config.Env}}{{println .}}{{end}}' }}"
+    nebula_sync_inspect_mounts_fmt: "{{ '{{json .Mounts}}' }}"
+  when: nebula_sync_use_secret_files | bool
+
+- name: Inspect existing nebula-sync environment
+  when: nebula_sync_use_secret_files | bool
+  no_log: true
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - --format
+      - "{{ nebula_sync_inspect_env_fmt }}"
+      - "{{ nebula_sync_container_name }}"
+  register: nebula_sync_existing_env
+  changed_when: false
+  failed_when: false
+
+- name: Inspect existing nebula-sync mounts
+  when: nebula_sync_use_secret_files | bool
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - --format
+      - "{{ nebula_sync_inspect_mounts_fmt }}"
+      - "{{ nebula_sync_container_name }}"
+  register: nebula_sync_existing_mounts
+  changed_when: false
+  failed_when: false
+
+- name: Detect legacy plaintext nebula-sync container state
+  no_log: true
+  ansible.builtin.set_fact:
+    nebula_sync_existing_mount_destinations: >-
+      {{
+        (nebula_sync_existing_mounts.stdout | default('[]') | from_json)
+        | map(attribute='Destination')
+        | list
+      }}
+    nebula_sync_existing_plaintext_env: >-
+      {{
+        (nebula_sync_existing_env.stdout_lines | default([]) | select('search', '^PRIMARY=.*\\|') | list | length > 0)
+        or
+        (nebula_sync_existing_env.stdout_lines | default([]) | select('search', '^REPLICAS=.*\\|') | list | length > 0)
+      }}
+    nebula_sync_existing_missing_secret_mounts: >-
+      {{
+        (nebula_sync_secret_container_dir ~ '/' ~ nebula_sync_primary_secret_filename)
+        not in
+        (
+          (nebula_sync_existing_mounts.stdout | default('[]') | from_json)
+          | map(attribute='Destination')
+          | list
+        )
+        or
+        (nebula_sync_secret_container_dir ~ '/' ~ nebula_sync_replicas_secret_filename)
+        not in
+        (
+          (nebula_sync_existing_mounts.stdout | default('[]') | from_json)
+          | map(attribute='Destination')
+          | list
+        )
+      }}
+  when:
+    - nebula_sync_use_secret_files | bool
+    - nebula_sync_existing_env.rc == 0
+    - nebula_sync_existing_mounts.rc == 0
+
 - name: Determine whether nebula-sync must be recreated
   ansible.builtin.set_fact:
     nebula_sync_force_recreate: >-
@@ -96,7 +167,35 @@
         or (nebula_sync_env_template.changed | default(false) | bool)
         or (nebula_sync_primary_secret.changed | default(false) | bool)
         or (nebula_sync_replicas_secret.changed | default(false) | bool)
+        or (nebula_sync_existing_plaintext_env | default(false) | bool)
+        or (nebula_sync_existing_missing_secret_mounts | default(false) | bool)
       }}
+
+- name: Remove legacy plaintext nebula-sync container before secure-mode recreate
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ nebula_compose_file | default(nebula_sync_dir ~ '/docker-compose.yml') }}"
+      - down
+      - --remove-orphans
+  args:
+    chdir: "{{ nebula_sync_dir }}"
+  register: nebula_sync_compose_down
+  changed_when: true
+  failed_when: nebula_sync_compose_down.rc != 0
+  when:
+    - nebula_sync_use_secret_files | bool
+    - nebula_sync_existing_plaintext_env | default(false) | bool
+
+- name: Remove legacy plaintext nebula-sync container by name before secure-mode recreate
+  community.docker.docker_container:
+    name: "{{ nebula_sync_container_name }}"
+    state: absent
+  when:
+    - nebula_sync_use_secret_files | bool
+    - nebula_sync_existing_plaintext_env | default(false) | bool
 
 - name: Bring up nebula-sync with Docker Compose v2
   community.docker.docker_compose_v2:

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -32,6 +32,10 @@ pihole_rocky_network_debug_flush_nft: false
 # Helpful for Rocky/Vagrant debugging when published 53/udp or bridge DNS is unreliable.
 pihole_use_host_network: false
 
+# Explicit maintenance/debug escape hatch. NAT/firewall reconciliation must not force
+# a Pi-hole app-container recreation on otherwise unchanged runs.
+pihole_force_recreate: false
+
 # When true on Debian/Ubuntu, disable systemd-resolved stub DNS so host port 53 can be used
 # by Docker (Pi-hole publish). Independent of firewalld — do not tie this to pihole_firewall_deploy.
 pihole_configure_systemd_resolved: true

--- a/roles/pihole/tasks/deploypi.yml
+++ b/roles/pihole/tasks/deploypi.yml
@@ -62,7 +62,7 @@
   vars:
     _pihole_compose_needs_recreate: >-
       {{
-        (not (pihole_docker_manage_iptables | default(true) | bool))
+        (pihole_force_recreate | default(false) | bool)
         or (pihole_compose_template.changed | default(false) | bool)
       }}
   community.docker.docker_compose_v2:


### PR DESCRIPTION
## Summary
- Gate bootstrap/update keepalived resume on direct DNS health checks and verify VIP DNS after successful rolling runs.
- Update Nebula Sync HA verification for secret-file mode, safe cleanup, and legacy plaintext-container migration.
- Decouple Pi-hole container recreation from Docker NAT fallback, with an explicit force-recreate override.

## Root Cause
- Rolling playbooks resumed keepalived before local DNS health gates completed.
- Nebula Sync verification still assumed plaintext PRIMARY/REPLICAS env values and did not handle legacy containers after switching to secret files.
- Pi-hole compose recreation was tied to Docker iptables/NAT workaround mode rather than application config changes.

## Validation
- ansible-playbook --syntax-check for bootstrap-pihole, update-pihole, sync, and molecule/common/verify_ha.yml.
- yamllint on changed playbooks, role tasks/defaults, and molecule verifier.
- ansible-lint on changed playbooks, role tasks/defaults, and molecule verifier.
- git diff --check.

## Notes
- Full Molecule/Vagrant HA verification was exercised iteratively by the local scenario owner; this PR keeps the scenario self-healing for legacy Nebula Sync container state.