### PR TITLE
chore: promote dev to master (HA fixes, secure defaults, CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
       - name: Syntax check playbooks
         run: |
           ansible-playbook -i inventory/ci/ci.yml playbooks/bootstrap-pihole.yaml --syntax-check
+          ansible-playbook -i inventory/ci/ci.yml playbooks/bootstrap-pihole.yaml --syntax-check \
+            -e pihole_enable_unbound=false -e '{"pihole_upstream_resolvers":["1.1.1.1"]}'
           ansible-playbook -i inventory/ci/ci.yml playbooks/update-pihole.yaml --syntax-check
           ansible-playbook -i inventory/ci/ci.yml playbooks/keepalived.yaml --syntax-check
           ansible-playbook -i inventory/ci/ci.yml playbooks/sync.yaml --syntax-check
@@ -110,6 +112,9 @@ jobs:
       - name: Check-mode converge (ci-bootstrap)
         run: |
           ansible-playbook -i inventory/ci/ci.yml playbooks/ci-bootstrap.yaml --check
+
+      - name: Validate Pi-hole Compose modes
+        run: ansible-playbook playbooks/ci-validate-pihole-modes.yaml
 
   ci-safety-checks:
     name: Hosted CI safety checks
@@ -155,3 +160,8 @@ jobs:
                   raise SystemExit(f"{relpath} missing keys: {missing}")
           print("Molecule scenario structure checks passed.")
           PY
+
+      - name: Validate default container image matrix
+        run: |
+          python scripts/default-container-images.py --github-matrix
+          python scripts/validate-secure-defaults.py

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,3 +70,59 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4.36.0
         with:
           sarif_file: trivy-results.sarif
+
+  default-images:
+    name: Resolve default container images
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.images.outputs.matrix }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install YAML parser
+        run: python -m pip install --disable-pip-version-check PyYAML
+
+      - name: Resolve image matrix from role defaults
+        id: images
+        run: |
+          echo "matrix=$(python scripts/default-container-images.py --github-matrix)" \
+            >> "$GITHUB_OUTPUT"
+
+  trivy-images:
+    name: Trivy image scan - ${{ matrix.key }}
+    runs-on: ubuntu-latest
+    needs: default-images
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.default-images.outputs.matrix) }}
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Run Trivy against default image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image }}
+          scanners: vuln
+          format: sarif
+          output: trivy-${{ matrix.key }}.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Upload Trivy image results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4.36.0
+        with:
+          sarif_file: trivy-${{ matrix.key }}.sarif
+          category: trivy-image-${{ matrix.key }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -108,6 +108,9 @@ jobs:
       security-events: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
       - name: Run Trivy against default image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -118,7 +121,9 @@ jobs:
           output: trivy-${{ matrix.key }}.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: "1"
+          # Default images are upstream artifacts we do not build here. Upload
+          # findings to code scanning, but keep PR gating on repository content.
+          exit-code: "0"
 
       - name: Upload Trivy image results
         if: always()

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ ansible-playbook -i /path/to/your/inventory.yml playbooks/bootstrap-pihole.yaml
 
 ### `playbooks/bootstrap-pihole.yaml`
 
-First-time (and repeatable) full bootstrap: system prep, Docker, Unbound, Pi-hole, keepalived, etc. (see the play for the exact role list).
+First-time (and repeatable) full bootstrap: system prep, Docker, optional Unbound,
+Pi-hole, keepalived, etc. (see the play for the exact role list).
 
 If Docker tasks fail on a first run, reboot the host and re-run.
 
@@ -71,6 +72,28 @@ On RedHat/Rocky hosts the Docker role installs `kernel-modules-extra` by default
 ```yaml
 docker_install_kernel_modules_extra: false
 ```
+
+Docker group membership is root-equivalent and defaults to no users. Lab or
+administrative inventories can grant it explicitly:
+
+```yaml
+docker_group_users:
+  - vagrant
+```
+
+The Docker and keepalived roles leave IPv4 forwarding unchanged by default.
+Enable it only for a topology that routes traffic between interfaces:
+
+```yaml
+docker_enable_ip_forward: true
+# or, for a keepalived-specific routed topology:
+keepalived_enable_ip_forward: true
+```
+
+On RedHat/Rocky, `keepalived_t` remains enforcing by default. The
+`keepalived_selinux_permissive: true` compatibility escape hatch weakens
+SELinux enforcement and should only be used for a known denial while a narrow
+policy fix is prepared.
 
 `docker_disable_ipv6` now defaults to `false` for production safety. Set it explicitly in
 lab inventories where guest networking requires the workaround (for example Vagrant/Rocky).
@@ -95,16 +118,33 @@ Security defaults:
 - Known placeholders/defaults (`Testing 101`, `Intranet`, `CHANGE_ME`, empty value) are rejected by role assertions.
 - Pi-hole compose files are rendered with root-only permissions (`0600`) in both normal and Unbound integration paths.
 
-Unbound is deployed before Pi-hole and can be used as Pi-hole's upstream resolver over a shared Docker network. By default the Unbound role now chooses an image from `unbound_image_arch_map` using the target host architecture:
+Unbound is deployed before Pi-hole by default and can be used as Pi-hole's
+upstream resolver over a shared Docker network. Disable it explicitly and
+provide upstream resolvers for a Pi-hole-only deployment:
+
+```yaml
+pihole_enable_unbound: false
+pihole_upstream_resolvers:
+  - "1.1.1.1"
+  - "1.0.0.1"
+```
+
+When Unbound is disabled, the Pi-hole role removes the managed Unbound
+container, Pi-hole is not attached to the shared Unbound network, and the role
+requires either `pihole_upstream_resolvers` or an explicit
+`pihole_environment_variables.FTLCONF_dns_upstreams` value.
+
+By default the Unbound role chooses a pinned image from
+`unbound_image_arch_map` using the target host architecture:
 
 ```yaml
 unbound_image: ""  # empty means auto-select
 unbound_image_arch_map:
-  x86_64: "mvance/unbound:latest"
-  amd64: "mvance/unbound:latest"
-  aarch64: "vincejv/unbound:latest"
-  arm64: "vincejv/unbound:latest"
-  armv7l: "vincejv/unbound:latest"
+  x86_64: "mvance/unbound:1.19.3"
+  amd64: "mvance/unbound:1.19.3"
+  aarch64: "vincejv/unbound:1.19.3"
+  arm64: "vincejv/unbound:1.19.3"
+  armv7l: "vincejv/unbound:1.19.3"
 ```
 
 Set `unbound_image` explicitly in inventory to override that selection. For Pi-hole v6, use `FTLCONF_dns_upstreams` rather than the older `PIHOLE_DNS_` variable:
@@ -151,6 +191,11 @@ upstream names (for example `unbound`) are resolved in the same network context
 Pi-hole uses. After all nodes pass and rejoin, the playbooks verify DNS through
 the VIP.
 
+Keepalived health checks require both the configured Pi-hole container to be
+running and Pi-hole DNS to answer functionally. Container checks use `sg docker`
+so they work under keepalived's script execution context. This prevents another
+local DNS listener from masking a stopped Pi-hole container during HA failover.
+
 Pi-hole container recreation is driven by Compose/configuration changes or an
 explicit maintenance override:
 
@@ -173,7 +218,7 @@ Deploy or adjust keepalived HA between Pi-hole instances. Priorities and VIPs ar
 
 ### `playbooks/sync.yaml`
 
-Deploy [Nebula Sync](https://github.com/lovelaze/nebula-sync) on the **`nebula_sync_controller`** inventory group only (one orchestrator per primary→replica topology). Lab inventories define that group in [`inventory/vagrant.yml`](inventory/vagrant.yml) with `vagrant-pihole-01` as controller. Override `nebula_sync_image_tag` in inventory if you do not want `latest`.
+Deploy [Nebula Sync](https://github.com/lovelaze/nebula-sync) on the **`nebula_sync_controller`** inventory group only (one orchestrator per primary→replica topology). Lab inventories define that group in [`inventory/vagrant.yml`](inventory/vagrant.yml) with `vagrant-pihole-01` as controller. The role defaults to pinned tag `v0.11.1`; override `nebula_sync_image_tag` to test a different version.
 
 Nebula Sync defaults `nebula_sync_use_secret_files: true` so `PRIMARY` and `REPLICAS` credentials are written to mounted secret files (`PRIMARY_FILE` / `REPLICAS_FILE`) instead of plain env values where possible. The role defaults ownership to UID/GID `1001`, matching the upstream container user, and rejects placeholder credentials by default.
 
@@ -296,6 +341,11 @@ Hosted CI also runs lightweight safety checks for Molecule configuration files (
 sanity) that do not require Vagrant or a VM provider. Full Molecule Vagrant scenarios remain
 local/self-hosted validation steps.
 
+The security workflow scans repository content and every default deployed
+container image for HIGH/CRITICAL vulnerabilities. Image targets are derived
+from role defaults by `scripts/default-container-images.py`, so changing a
+default pin updates the scan matrix without duplicating image names.
+
 ## Operational docs
 
 - [Architecture](docs/architecture.md)
@@ -330,8 +380,10 @@ Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
 **Install a specific version:**
 
 ```bash
-ansible-galaxy collection install steveyminecraft.pihole:==1.1.0
+ansible-galaxy collection install steveyminecraft.pihole:==VERSION
 ```
+
+Replace `VERSION` with a published release such as `1.2.3`.
 
 See [GitHub releases](https://github.com/steveyminecraft/ansible-pihole/releases) and [`CHANGELOG.md`](CHANGELOG.md) for version history.
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ unbound_image: ""  # empty means auto-select
 unbound_image_arch_map:
   x86_64: "mvance/unbound:1.19.3"
   amd64: "mvance/unbound:1.19.3"
-  aarch64: "vincejv/unbound:1.19.3"
-  arm64: "vincejv/unbound:1.19.3"
-  armv7l: "vincejv/unbound:1.19.3"
+  aarch64: "vincejv/unbound:1.25.1"
+  arm64: "vincejv/unbound:1.25.1"
+  armv7l: "vincejv/unbound:1.25.1"
 ```
 
 Set `unbound_image` explicitly in inventory to override that selection. For Pi-hole v6, use `FTLCONF_dns_upstreams` rather than the older `PIHOLE_DNS_` variable:
@@ -351,8 +351,10 @@ and installs the collection artifact into an empty temporary collections path,
 resolves its Galaxy dependencies, and syntax-checks playbooks from the installed
 artifact rather than the source checkout.
 
-The security workflow scans repository content and every default deployed
-container image for HIGH/CRITICAL vulnerabilities. Image targets are derived
+The security workflow hard-fails on HIGH/CRITICAL findings in repository
+content. It also uploads code-scanning SARIF for every default deployed
+container image; image scans are report-only because those findings belong to
+upstream images we do not build in this repository. Image targets are derived
 from role defaults by `scripts/default-container-images.py`, so changing a
 default pin updates the scan matrix without duplicating image names.
 

--- a/inventory/vagrant.yml
+++ b/inventory/vagrant.yml
@@ -55,7 +55,8 @@ all:
     dnsmasq_listening: single
     pihole_container_name: pihole
     vagrant_env: true
-    docker_users: vagrant
+    docker_group_users:
+      - vagrant
     # Lab-only: avoid Docker image pulls depending on the guest's systemd-resolved stub.
     docker_daemon_dns:
       - "1.1.1.1"
@@ -79,3 +80,4 @@ all:
     pihole_network_external: true
     pihole_rocky_network_debug: true
     docker_disable_ipv6: true  # lab-only workaround for Rocky/Vagrant guest networking
+    docker_enable_ip_forward: true  # lab bridge/NAT topology requires forwarding

--- a/inventory/vagrant_libvirt.yml
+++ b/inventory/vagrant_libvirt.yml
@@ -49,7 +49,9 @@ all:
     pihole_container_name: pihole
     vagrant_env: true
     docker_disable_ipv6: true  # lab-only workaround for Rocky/Vagrant guest networking
-    docker_users: vagrant
+    docker_enable_ip_forward: true  # lab bridge/NAT topology requires forwarding
+    docker_group_users:
+      - vagrant
     # Lab-only: avoid Docker image pulls depending on the guest's systemd-resolved stub.
     docker_daemon_dns:
       - "1.1.1.1"

--- a/molecule/common/verify_ha.yml
+++ b/molecule/common/verify_ha.yml
@@ -3,6 +3,7 @@
 - name: Verify HA Pi-hole deployment (Molecule)
   hosts: all
   gather_facts: false
+  any_errors_fatal: true
   vars:
     vip_address: "{{ (pihole_vip_ipv4 | default('192.168.56.10/24')) | split('/') | first }}"
     node1: "{{ (groups['all'] | sort)[0] }}"
@@ -292,13 +293,13 @@
           }}
         nebula_sync_plaintext_primary_present: >-
           {{
-            ((nebula_sync_effective_env_lines | select('search', '^PRIMARY=.*\\|') | list | length) > 0)
-            or ((nebula_sync_env.stdout_lines | select('search', '^PRIMARY=.*\\|') | list | length) > 0)
+            ((nebula_sync_effective_env_lines | select('match', '^PRIMARY=') | list | length) > 0)
+            or ((nebula_sync_env.stdout_lines | select('match', '^PRIMARY=') | list | length) > 0)
           }}
         nebula_sync_plaintext_replicas_present: >-
           {{
-            ((nebula_sync_effective_env_lines | select('search', '^REPLICAS=.*\\|') | list | length) > 0)
-            or ((nebula_sync_env.stdout_lines | select('search', '^REPLICAS=.*\\|') | list | length) > 0)
+            ((nebula_sync_effective_env_lines | select('match', '^REPLICAS=') | list | length) > 0)
+            or ((nebula_sync_env.stdout_lines | select('match', '^REPLICAS=') | list | length) > 0)
           }}
         nebula_sync_mounted_secret_destinations: >-
           {{
@@ -816,50 +817,80 @@
           Precondition failed: container {{ ha_container_name }} not found on {{ node1 }}.
       when: inventory_hostname == node1
 
-    - name: Stop Pi-hole container on primary to trigger failover
-      community.docker.docker_container:
-        name: "{{ ha_container_name }}"
-        state: stopped
-      when: inventory_hostname == node1
+    - name: Verify container-stop health failover and restore primary
+      block:
+        - name: Stop Pi-hole container on primary to trigger failover
+          community.docker.docker_container:
+            name: "{{ ha_container_name }}"
+            state: stopped
+          when: inventory_hostname == node1
 
-    - name: Wait for VIP on backup after container stop on primary
-      ansible.builtin.command: ip -4 addr show
-      register: ip_node2_docker_failover
-      changed_when: false
-      when: inventory_hostname == node2
-      retries: 15
-      delay: 3
-      until: vip_address in ip_node2_docker_failover.stdout
+        - name: Wait for Keepalived health check to fail on primary
+          ansible.builtin.command: /etc/keepalived/check_pihole.sh
+          register: pihole_health_after_container_stop
+          changed_when: false
+          failed_when: false
+          when: inventory_hostname == node1
+          retries: 10
+          delay: 2
+          until: pihole_health_after_container_stop.rc != 0
 
-    - name: Assert VIP is on backup after container stop on primary
-      ansible.builtin.assert:
-        that:
-          - vip_address in ip_node2_docker_failover.stdout
-        fail_msg: >-
-          CONTAINER FAILOVER FAILED: VIP {{ vip_address }} not found on {{ node2 }}
-          after stopping container {{ ha_container_name }} on {{ node1 }}.
-      when: inventory_hostname == node2
+        - name: Assert Keepalived detects the stopped Pi-hole container
+          ansible.builtin.assert:
+            that:
+              - pihole_health_after_container_stop.rc != 0
+            fail_msg: >-
+              HEALTH CHECK FAILED: /etc/keepalived/check_pihole.sh remained healthy
+              after stopping container {{ ha_container_name }} on {{ node1 }}.
+          when: inventory_hostname == node1
 
-    - name: Collect addresses on primary after container stop
-      ansible.builtin.command: ip -4 addr show
-      register: ip_node1_post_container_stop
-      changed_when: false
-      when: inventory_hostname == node1
+        - name: Wait for VIP on backup after container stop on primary
+          ansible.builtin.command: ip -4 addr show
+          register: ip_node2_docker_failover
+          changed_when: false
+          when: inventory_hostname == node2
+          retries: 30
+          delay: 2
+          until: vip_address in ip_node2_docker_failover.stdout
 
-    - name: Assert VIP is absent from primary after container stop
-      ansible.builtin.assert:
-        that:
-          - vip_address not in ip_node1_post_container_stop.stdout
-        fail_msg: >-
-          CONTAINER FAILOVER INCOMPLETE: VIP {{ vip_address }} still present on {{ node1 }}
-          after stopping container {{ ha_container_name }}.
-      when: inventory_hostname == node1
+        - name: Assert VIP is on backup after container stop on primary
+          ansible.builtin.assert:
+            that:
+              - vip_address in ip_node2_docker_failover.stdout
+            fail_msg: >-
+              CONTAINER FAILOVER FAILED: VIP {{ vip_address }} not found on {{ node2 }}
+              after stopping container {{ ha_container_name }} on {{ node1 }}.
+          when: inventory_hostname == node2
 
-    - name: Start Pi-hole container on primary (restore)
-      community.docker.docker_container:
-        name: "{{ ha_container_name }}"
-        state: started
-      when: inventory_hostname == node1
+        - name: Collect addresses on primary after container stop
+          ansible.builtin.command: ip -4 addr show
+          register: ip_node1_post_container_stop
+          changed_when: false
+          when: inventory_hostname == node1
+
+        - name: Assert VIP is absent from primary after container stop
+          ansible.builtin.assert:
+            that:
+              - vip_address not in ip_node1_post_container_stop.stdout
+            fail_msg: >-
+              CONTAINER FAILOVER INCOMPLETE: VIP {{ vip_address }} still present on {{ node1 }}
+              after stopping container {{ ha_container_name }}.
+          when: inventory_hostname == node1
+      always:
+        - name: Start Pi-hole container on primary after container failover test
+          community.docker.docker_container:
+            name: "{{ ha_container_name }}"
+            state: started
+          when: inventory_hostname == node1
+
+        - name: Wait for Pi-hole DNS recovery after container failover test
+          ansible.builtin.command: /etc/keepalived/check_pihole.sh
+          register: pihole_health_after_container_restore
+          changed_when: false
+          when: inventory_hostname == node1
+          retries: 30
+          delay: 2
+          until: pihole_health_after_container_restore.rc == 0
 
     - name: Disable local DNS service on primary (functional failover test)
       ansible.builtin.command: docker exec {{ ha_container_name }} sh -lc "pkill -TERM pihole-FTL || true; exit 0"

--- a/molecule/default/converge-docker.yml
+++ b/molecule/default/converge-docker.yml
@@ -5,5 +5,6 @@
   gather_facts: true
   vars:
     docker_manage_iptables: false
+    docker_enable_ip_forward: true
   roles:
     - role: steveyminecraft.pihole.docker

--- a/molecule/nebula-sync-migration/verify.yml
+++ b/molecule/nebula-sync-migration/verify.yml
@@ -47,8 +47,8 @@
     - name: Assert legacy plaintext state was migrated
       ansible.builtin.assert:
         that:
-          - migrated_nebula_sync_env.stdout_lines | select('search', '^PRIMARY=.*\\|') | list | length == 0
-          - migrated_nebula_sync_env.stdout_lines | select('search', '^REPLICAS=.*\\|') | list | length == 0
+          - migrated_nebula_sync_env.stdout_lines | select('match', '^PRIMARY=') | list | length == 0
+          - migrated_nebula_sync_env.stdout_lines | select('match', '^REPLICAS=') | list | length == 0
           - ('PRIMARY_FILE=' ~ migration_primary_secret_path) in migrated_nebula_sync_env.stdout_lines
           - ('REPLICAS_FILE=' ~ migration_replicas_secret_path) in migrated_nebula_sync_env.stdout_lines
           - migration_primary_secret_path in migrated_nebula_sync_mount_destinations

--- a/playbooks/bootstrap-pihole.yaml
+++ b/playbooks/bootstrap-pihole.yaml
@@ -22,6 +22,7 @@
       tags: [docker, container]
     - role: steveyminecraft.pihole.unbound
       tags: [unbound, dns]
+      when: pihole_enable_unbound | default(true) | bool
     - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
   post_tasks:
@@ -94,10 +95,12 @@
           - "{{ pihole_bootstrap_health_qname | default(pihole_unbound_verify_qname | default('google.com')) }}"
       register: pihole_bootstrap_vip_dns
       changed_when: false
-      failed_when: >
+      retries: 30
+      delay: 2
+      until: >
         (pihole_bootstrap_vip_dns.stdout_lines
          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
-         | list | length) == 0
+         | list | length) > 0
       run_once: true
       when:
         - pihole_ha_mode | default(false) | bool

--- a/playbooks/ci-bootstrap.yaml
+++ b/playbooks/ci-bootstrap.yaml
@@ -19,7 +19,7 @@
 
     password_lock: false
     # Point Pi-hole image at something valid, but we're in --check anyway
-    pihole_image: "pihole/pihole:latest"
+    pihole_image: "pihole/pihole:2026.05.0"
     pihole_compose_dir: "/opt/pihole"
 
   roles:

--- a/playbooks/ci-validate-pihole-modes.yaml
+++ b/playbooks/ci-validate-pihole-modes.yaml
@@ -1,0 +1,55 @@
+---
+- name: Validate Pi-hole Compose modes
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    pihole_container_name: pihole
+    pihole_image: "pihole/pihole:2026.05.0"
+    pihole_dir_loc: /opt/pihole
+    pihole_network_name: dns_net
+    pihole_use_host_network: false
+    pihole_rocky_network_debug: false
+    pihole_docker_dns: []
+    pihole_webport_http: "80"
+    pihole_webport_https: "443"
+    pihole_environment_variables:
+      DHCP_ACTIVE: false
+      FTLCONF_dns_upstreams: "1.1.1.1;1.0.0.1"
+  tasks:
+    - name: Render Pi-hole-only Compose configuration
+      ansible.builtin.set_fact:
+        pihole_only_compose: >-
+          {{
+            lookup(
+              'ansible.builtin.template',
+              playbook_dir ~ '/../roles/pihole/templates/docker-compose.yml.j2',
+              template_vars={'pihole_enable_unbound': false}
+            )
+            | from_yaml
+          }}
+
+    - name: Assert Pi-hole-only mode has no Unbound network assumptions
+      ansible.builtin.assert:
+        that:
+          - pihole_only_compose.networks is not defined
+          - pihole_only_compose.services.pihole.networks is not defined
+          - "'FTLCONF_dns_upstreams=1.1.1.1;1.0.0.1' in pihole_only_compose.services.pihole.environment"
+
+    - name: Render Pi-hole with Unbound Compose configuration
+      ansible.builtin.set_fact:
+        pihole_unbound_compose: >-
+          {{
+            lookup(
+              'ansible.builtin.template',
+              playbook_dir ~ '/../roles/pihole/templates/docker-compose.yml.j2',
+              template_vars={'pihole_enable_unbound': true}
+            )
+            | from_yaml
+          }}
+
+    - name: Assert Unbound mode uses the shared DNS network
+      ansible.builtin.assert:
+        that:
+          - pihole_network_name in pihole_unbound_compose.networks
+          - pihole_network_name in pihole_unbound_compose.services.pihole.networks

--- a/playbooks/update-pihole.yaml
+++ b/playbooks/update-pihole.yaml
@@ -83,10 +83,12 @@
           - "{{ pihole_update_health_qname | default(pihole_unbound_verify_qname | default('google.com')) }}"
       register: pihole_update_vip_dns
       changed_when: false
-      failed_when: >
+      retries: 30
+      delay: 2
+      until: >
         (pihole_update_vip_dns.stdout_lines
          | select('match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')
-         | list | length) == 0
+         | list | length) > 0
       run_once: true
       when:
         - pihole_ha_mode | default(false) | bool

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -2,4 +2,11 @@
 
 Install and configure Docker Engine and Docker Compose for Pi-hole deployment targets.
 
+Security-sensitive defaults:
+
+- `docker_group_users: []` grants no Docker group membership. List users
+  explicitly only when root-equivalent Docker access is intended.
+- `docker_enable_ip_forward: false` leaves host IPv4 forwarding unchanged.
+  Enable it for routed bridge/NAT topologies that require it.
+
 Part of the `steveyminecraft.pihole` collection.

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -24,6 +24,14 @@ docker_ipv6_fixed_cidr: ""
 # stub DNS during Docker Hub image pulls.
 docker_daemon_dns: []
 
+# Docker group membership grants root-equivalent host access. Add users only
+# when an inventory explicitly opts them in.
+docker_group_users: []
+
+# Docker may require host forwarding for routed bridge/NAT topologies. Keep the
+# host setting unchanged unless the inventory explicitly requests it.
+docker_enable_ip_forward: false
+
 # When Docker iptables is off on EL, discover IPv4 subnets (docker network inspect) and add
 # nftables masquerade per subnet (iptables MASQUERADE is unreliable on EL9+ nf_tables); re-run
 # after compose so project networks exist. Falls back to 172.16.0.0/12 if discovery is empty.

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -248,7 +248,9 @@
     value: "1"
     sysctl_set: true
     reload: true
-  when: ansible_facts['os_family'] == 'RedHat'
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - docker_enable_ip_forward | default(false) | bool
 
 - name: Configure Docker daemon to not manage iptables (VirtualBox/vagrant workaround)
   ansible.builtin.copy:
@@ -302,18 +304,8 @@
   failed_when: false
   when: ansible_facts['os_family'] == 'RedHat'
 
-- name: Install Docker SDK for python
-  pip:
-    name:
-      - docker
-    extra_args: "--user --timeout 120"
-    break_system_packages: true
-
-- name: Add user to docker group
-  ansible.builtin.user:
-    name: "{{ ansible_user }}"
-    append: true
-    groups: docker
+- name: Configure Docker SDK and explicit group users
+  ansible.builtin.import_tasks: users.yml
 
 - name: Configure Docker daemon (RedHat family)
   ansible.builtin.copy:
@@ -386,7 +378,7 @@
     - not (docker_ipv6_enabled | default(false) | bool)
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
 
 # After Docker restarts (handler), re-apply NAT — restart can reset netfilter state before rules land.
 - name: EL container egress when Docker does not manage iptables (NAT fallback)

--- a/roles/docker/tasks/users.yml
+++ b/roles/docker/tasks/users.yml
@@ -1,0 +1,14 @@
+---
+- name: Install Docker SDK for python
+  ansible.builtin.pip:
+    name:
+      - docker
+    extra_args: "--user --timeout 120"
+    break_system_packages: true
+
+- name: Add configured users to Docker group
+  ansible.builtin.user:
+    name: "{{ item }}"
+    append: true
+    groups: docker
+  loop: "{{ docker_group_users | default([]) }}"

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -2,8 +2,22 @@
 
 Configure keepalived for Pi-hole high availability with VIP failover.
 
-The health script performs a functional DNS query against local Pi-hole on
-`127.0.0.1:53`; set `PIHOLE_HA_HEALTH_DOMAIN` in the service environment to
-override the default `cloudflare.com` query name.
+The health script requires the configured Pi-hole container (`PIHOLE_CONTAINER`,
+default `pihole`) to be running, then performs a functional DNS query against
+local Pi-hole on `127.0.0.1:53`. Container checks use `sg docker` so they still
+work when keepalived runs the script without supplementary groups. The script
+uses `set -o pipefail` only (never `set -e`) because keepalived's script runner
+mishandles common bash control-flow patterns. Set `PIHOLE_HA_HEALTH_DOMAIN` in
+the keepalived service environment to override the default `cloudflare.com`
+query name.
+
+The role leaves IPv4 forwarding disabled by default because a local service VIP
+does not normally require routing. Set `keepalived_enable_ip_forward: true`
+only for a routed topology.
+
+On RedHat-family hosts, `keepalived_t` remains enforcing by default. Setting
+`keepalived_selinux_permissive: true` is a compatibility escape hatch that
+weakens SELinux enforcement; prefer correcting labels, ports, capabilities, or
+a narrowly scoped policy.
 
 Part of the `steveyminecraft.pihole` collection.

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# A local service VIP does not normally require packet forwarding.
+keepalived_enable_ip_forward: false
+
+# Compatibility escape hatch for deployments with a known keepalived SELinux
+# denial. Prefer a narrowly scoped policy fix.
+keepalived_selinux_permissive: false

--- a/roles/keepalived/files/check_pihole.sh
+++ b/roles/keepalived/files/check_pihole.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -o pipefail
 
 PIHOLE_CONTAINER="${PIHOLE_CONTAINER:-pihole}"
 PIHOLE_HEALTH_DOMAIN="${PIHOLE_HA_HEALTH_DOMAIN:-cloudflare.com}"
 PIHOLE_HEALTH_SERVER="${PIHOLE_HA_HEALTH_SERVER:-127.0.0.1}"
 PIHOLE_HEALTH_PORT="${PIHOLE_HA_HEALTH_PORT:-53}"
 
-# Prefer functional DNS checks over container metadata.
+# Keepalived drops supplementary groups for script_user. Use sg(1) for docker
+# inspect/exec. Avoid set -e and compound conditionals: keepalived's script
+# runner mishandles them. Run the container check first, then functional DNS.
+sg docker -c "docker inspect --format '{{.State.Running}}' ${PIHOLE_CONTAINER}" 2>/dev/null \
+  | grep -qx true
+
 if command -v dig >/dev/null 2>&1; then
   dig +time=2 +tries=1 +short "@${PIHOLE_HEALTH_SERVER}" -p "${PIHOLE_HEALTH_PORT}" "${PIHOLE_HEALTH_DOMAIN}" \
     | grep -q .
 else
-  docker exec "${PIHOLE_CONTAINER}" sh -lc \
-    "dig +time=2 +tries=1 +short @127.0.0.1 -p 53 ${PIHOLE_HEALTH_DOMAIN}" \
+  sg docker -c "docker exec ${PIHOLE_CONTAINER} sh -lc \
+    'dig +time=2 +tries=1 +short @127.0.0.1 -p 53 ${PIHOLE_HEALTH_DOMAIN}'" \
     | grep -q .
 fi

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -12,9 +12,10 @@
     value: '1'
     state: present
     reload: true
+  when: keepalived_enable_ip_forward | default(false) | bool
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
   when: not (keepalived_defer_service_restart | default(false) | bool)
 
 - name: Install keepalived Debian
@@ -25,7 +26,7 @@
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install keepalived Rocky
-  yum:
+  ansible.builtin.dnf:
     name:
       - kernel-headers
       - kernel-devel
@@ -35,10 +36,10 @@
     state: present
   when: ansible_facts['os_family'] == 'RedHat'
 
-- name: Change the keepalived_t domain to permissive
+- name: Configure keepalived_t permissive compatibility mode
   community.general.selinux_permissive:
     name: keepalived_t
-    permissive: true
+    permissive: "{{ keepalived_selinux_permissive | default(false) | bool }}"
   when: ansible_facts['os_family'] == 'RedHat'
 
 # Since yum doesn't like using notify because yum we have to this instead
@@ -57,18 +58,18 @@
   when: keepalived_defer_service_restart | default(false) | bool
 
 - name: Copy check_pihole.sh
-  copy:
+  ansible.builtin.copy:
     dest: /etc/keepalived/check_pihole.sh
     src: check_pihole.sh
     mode: "0755"
 
 # Finds the IP_ADDRS of the group and removes the ansible_host ip's from it's peer list
 - name: Find Local IP Addresses
-  set_fact:
+  ansible.builtin.set_fact:
     keepalived_local_ips: "{{ ansible_facts['all_ipv4_addresses'] + ansible_facts['all_ipv6_addresses'] }}"
 
 - name: Create a list of peer IPs excluding local IPs
-  set_fact:
+  ansible.builtin.set_fact:
     keepalived_peer_list: >-
       {{ groups['all']
          | map('extract', hostvars, 'ansible_host')
@@ -77,7 +78,7 @@
 
 # Step 3: Debug the keepalived_peer_list
 - name: Debug keepalived_peer_list
-  debug:
+  ansible.builtin.debug:
     msg: "Peer IPs with /24 for host {{ inventory_hostname }}: {{ keepalived_peer_list }}"
 
 # Vagrant: default route is often the NAT NIC; VRRP must bind to private_network (names vary: eth1, ens6, enp0s8, …).
@@ -110,7 +111,7 @@
         keepalived_vrrp_src_address: "{{ ansible_host | trim }}"
 
 - name: Configure keepalived
-  template:
+  ansible.builtin.template:
     dest: /etc/keepalived/keepalived.conf
     src: keepalived.j2
     owner: root
@@ -127,5 +128,5 @@
   notify: Restart firewall config
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers
   when: not (keepalived_defer_service_restart | default(false) | bool)

--- a/roles/pihole/README.md
+++ b/roles/pihole/README.md
@@ -1,5 +1,21 @@
 # pihole
 
+Set `pihole_enable_unbound: false` for a Pi-hole-only deployment and provide
+explicit upstreams:
+
+```yaml
+pihole_enable_unbound: false
+pihole_upstream_resolvers:
+  - "1.1.1.1"
+  - "1.0.0.1"
+```
+
+Disabling Unbound removes the managed Unbound container and keeps Pi-hole off
+the shared Unbound network.
+
+The default Pi-hole image is pinned. Override `pihole_image` deliberately when
+testing or upgrading to another release.
+
 Deploy Pi-hole in Docker (Pi-hole v6) with optional Unbound upstream integration.
 
 Sourced from [docker-pihole](https://github.com/steveyminecraft/docker-pihole) with ansible-pihole compatibility changes applied in this collection.

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -8,7 +8,14 @@
 # tasks/main.yml aligns pihole_dir_loc so volume paths match the playbook.
 pihole_dir_loc: '/opt/pihole'
 pihole_compose_dir: "{{ pihole_dir_loc }}"
+pihole_image: "pihole/pihole:2026.05.0"
 pihole_firewall_deploy: "{{ (vars['firewall_deploy'] if ('firewall_deploy' in vars) else false) | bool }}"
+
+# Deploy and integrate Unbound by default for backwards compatibility. When
+# disabled, configure at least one explicit upstream resolver below or through
+# pihole_environment_variables.FTLCONF_dns_upstreams.
+pihole_enable_unbound: true
+pihole_upstream_resolvers: []
 
 # Must stay aligned with roles/docker/defaults — same variable is used in both roles; last role used to
 # win in defaults, so a literal `true` here overwrote the docker role and broke EL/Vagrant bridge egress.

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -43,6 +43,38 @@
       Set pihole_startup_dns when pihole_override_container_resolver=true.
   when: pihole_override_container_resolver | default(false) | bool
 
+- name: Validate explicit Pi-hole upstreams when Unbound is disabled
+  ansible.builtin.assert:
+    that:
+      - >-
+        (pihole_upstream_resolvers | default([]) | length > 0)
+        or
+        (
+          pihole_environment_variables.FTLCONF_dns_upstreams is defined
+          and (pihole_environment_variables.FTLCONF_dns_upstreams | string | length > 0)
+        )
+    fail_msg: >-
+      Set pihole_upstream_resolvers or pihole_environment_variables.FTLCONF_dns_upstreams
+      when pihole_enable_unbound=false.
+  when: not (pihole_enable_unbound | default(true) | bool)
+
+- name: Configure explicit Pi-hole upstream resolvers
+  ansible.builtin.set_fact:
+    pihole_environment_variables: >-
+      {{
+        pihole_environment_variables
+        | combine({'FTLCONF_dns_upstreams': pihole_upstream_resolvers | join(';')}, recursive=True)
+      }}
+  when:
+    - not (pihole_enable_unbound | default(true) | bool)
+    - pihole_upstream_resolvers | default([]) | length > 0
+
+- name: Remove managed Unbound container when disabled
+  community.docker.docker_container:
+    name: "{{ unbound_container_name | default('unbound') }}"
+    state: absent
+  when: not (pihole_enable_unbound | default(true) | bool)
+
 - name: Debian setup tasks
   ansible.builtin.include_tasks: debian.yml
   when: ansible_facts['distribution'] in ['Debian', 'Ubuntu']
@@ -67,7 +99,14 @@
 
 - name: Added Unbound
   ansible.builtin.include_tasks: unbound.yml
-  when: not (pihole_use_host_network | default(false) | bool)
+  when:
+    - pihole_enable_unbound | default(true) | bool
+    - not (pihole_use_host_network | default(false) | bool)
+
+- name: Record that Unbound integration is disabled
+  ansible.builtin.set_fact:
+    pihole_unbound_present: false
+  when: not (pihole_enable_unbound | default(true) | bool)
 
 - name: Verify Pi-hole deployment
   ansible.builtin.include_tasks: verify.yml

--- a/roles/pihole/templates/docker-compose.yml.j2
+++ b/roles/pihole/templates/docker-compose.yml.j2
@@ -1,5 +1,5 @@
 ---
-{% if (not (pihole_use_host_network | default(false) | bool)) and (pihole_network_name is defined and pihole_network_name | string | length > 0) %}
+{% if (pihole_enable_unbound | default(true) | bool) and (not (pihole_use_host_network | default(false) | bool)) and (pihole_network_name is defined and pihole_network_name | string | length > 0) %}
 networks:
   {{ pihole_network_name }}:
     external: true
@@ -42,7 +42,7 @@ services:
 {% endfor %}
 {% endif %}
 {% if not (pihole_use_host_network | default(false) | bool) %}
-{% if pihole_network_name is defined and pihole_network_name | string | length > 0 %}
+{% if (pihole_enable_unbound | default(true) | bool) and (pihole_network_name is defined and pihole_network_name | string | length > 0) %}
     networks:
       - {{ pihole_network_name }}
 {% endif %}

--- a/roles/unbound/README.md
+++ b/roles/unbound/README.md
@@ -10,6 +10,11 @@ Runs Unbound DNS resolver in Docker via Docker Compose v2.
 - `unbound_publish_host_ip` (default `127.0.0.1`)
 - `unbound_publish_host_port` (default `5335`)
 - `unbound_port` (default `5335`)
+- `unbound_image` (default empty, selects from `unbound_image_arch_map`)
+
+The default image map uses pinned tags by architecture. x86_64/amd64 hosts use
+`mvance/unbound:1.19.3`; ARM hosts use `vincejv/unbound:1.25.1` because the
+`vincejv/unbound` repository does not publish a `1.19.3` tag.
 
 ## Example
 

--- a/roles/unbound/defaults/main.yml
+++ b/roles/unbound/defaults/main.yml
@@ -7,13 +7,13 @@ unbound_compose_file: "{{ unbound_compose_dir }}/docker-compose.yml"
 # Leave empty to select from unbound_image_arch_map based on the host architecture.
 # Set this explicitly in inventory to override the automatic selection.
 unbound_image: ""
-unbound_image_arch_default: "vincejv/unbound:1.19.3"
+unbound_image_arch_default: "vincejv/unbound:1.25.1"
 unbound_image_arch_map:
   x86_64: "mvance/unbound:1.19.3"
   amd64: "mvance/unbound:1.19.3"
-  aarch64: "vincejv/unbound:1.19.3"
-  arm64: "vincejv/unbound:1.19.3"
-  armv7l: "vincejv/unbound:1.19.3"
+  aarch64: "vincejv/unbound:1.25.1"
+  arm64: "vincejv/unbound:1.25.1"
+  armv7l: "vincejv/unbound:1.25.1"
 unbound_container_name: "unbound"
 unbound_hostname: "{{ unbound_container_name }}"
 unbound_restart_policy: "unless-stopped"

--- a/roles/unbound/tasks/main.yml
+++ b/roles/unbound/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create Supporting Folders
-  include_tasks: prep.yml
+  ansible.builtin.include_tasks: prep.yml
 
 - name: Deploy Unbound Container
-  include_tasks: deploy.yml
+  ansible.builtin.include_tasks: deploy.yml
 
 - name: Add Refres Script for Root Hints
-  include_tasks: refresh.yml
+  ansible.builtin.include_tasks: refresh.yml
 
 - name: Check Container is working
-  include_tasks: verify.yml
+  ansible.builtin.include_tasks: verify.yml

--- a/scripts/default-container-images.py
+++ b/scripts/default-container-images.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Emit the default deployed container images from role defaults."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_defaults(role: str) -> dict:
+    path = ROOT / "roles" / role / "defaults" / "main.yml"
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def image_key(image: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", image).strip("-")
+
+
+def default_images() -> list[str]:
+    pihole = load_defaults("pihole")
+    unbound = load_defaults("unbound")
+    nebula = load_defaults("nebula_sync")
+
+    images = {
+        pihole["pihole_image"],
+        unbound["unbound_image_arch_default"],
+        *unbound["unbound_image_arch_map"].values(),
+        f"{nebula['nebula_sync_image']}:{nebula['nebula_sync_image_tag']}",
+    }
+    return sorted(images)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--github-matrix",
+        action="store_true",
+        help="emit a GitHub Actions include matrix",
+    )
+    args = parser.parse_args()
+
+    images = default_images()
+    if args.github_matrix:
+        print(
+            json.dumps(
+                {
+                    "include": [
+                        {"image": image, "key": image_key(image)}
+                        for image in images
+                    ]
+                },
+                separators=(",", ":"),
+            )
+        )
+        return
+
+    print("\n".join(images))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Create project virtualenv (env/) with Python 3.13 or 3.14 (first match wins).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+pick_python() {
+  for candidate in python3.14 python3.13 python3; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+  echo "No python3 found. Install Python 3.13 or 3.14 (e.g. sudo apt install python3.14 python3.14-venv)." >&2
+  exit 1
+}
+
+PY="$(pick_python)"
+VER="$("$PY" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+
+if [[ "$VER" != "3.13" && "$VER" != "3.14" ]]; then
+  echo "Unsupported Python $VER (supported: 3.13, 3.14)." >&2
+  exit 1
+fi
+
+echo "Using $PY ($VER) -> $ROOT/env"
+rm -rf env
+"$PY" -m venv env
+# shellcheck source=/dev/null
+source env/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+echo
+echo "Activate: source env/bin/activate"
+echo "Then:     ./scripts/install-ansible-collections.sh"
+ansible --version | head -3

--- a/scripts/validate-secure-defaults.py
+++ b/scripts/validate-secure-defaults.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Validate security-sensitive collection defaults and lab opt-ins."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_yaml(relative_path: str) -> dict:
+    path = ROOT / relative_path
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def main() -> None:
+    docker = load_yaml("roles/docker/defaults/main.yml")
+    keepalived = load_yaml("roles/keepalived/defaults/main.yml")
+    pihole = load_yaml("roles/pihole/defaults/main.yml")
+    vagrant = load_yaml("inventory/vagrant.yml")["all"]["vars"]
+    vagrant_libvirt = load_yaml("inventory/vagrant_libvirt.yml")["all"]["vars"]
+
+    require(docker["docker_group_users"] == [], "Docker group users must default to empty")
+    require(not docker["docker_enable_ip_forward"], "Docker IPv4 forwarding must default off")
+    require(
+        not keepalived["keepalived_enable_ip_forward"],
+        "Keepalived IPv4 forwarding must default off",
+    )
+    require(
+        not keepalived["keepalived_selinux_permissive"],
+        "Keepalived SELinux permissive mode must default off",
+    )
+    require(pihole["pihole_enable_unbound"], "Unbound compatibility default must remain enabled")
+    require(
+        pihole["pihole_upstream_resolvers"] == [],
+        "Pi-hole fallback upstreams must not be silently supplied",
+    )
+    require(":latest" not in pihole["pihole_image"], "Pi-hole default image must be pinned")
+
+    for name, lab in (("vagrant", vagrant), ("vagrant_libvirt", vagrant_libvirt)):
+        require(
+            lab["docker_group_users"] == ["vagrant"],
+            f"{name} must explicitly request Docker group membership",
+        )
+        require(
+            lab["docker_enable_ip_forward"] is True,
+            f"{name} must explicitly request its lab forwarding topology",
+        )
+
+    print("Security-sensitive defaults and lab opt-ins are valid.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Promote `dev` to `master` after PR #98 merge (HA keepalived health checks, Molecule verify stabilization).
- Includes secure-defaults validation, CI bootstrap/mode coverage, Docker user group handling, and report-only upstream image scans in Security workflow.
- Updates ARM Unbound default image to `vincejv/unbound:1.25.1`.

## Test plan
- [x] Molecule `default`, `ubuntu`, and `ubuntu-26.04` scenarios pass locally
- [x] CI on `dev` green (lint, syntax, collection build, Trivy, CodeQL)
- [x] PR #98 merged to `dev`


Made with [Cursor](https://cursor.com)