### PR TITLE
[codex] Promote dev to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
               "molecule/ubuntu-26.04/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
               "molecule/default/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
               "molecule/nebula-sync-migration/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
+              "molecule/pihole-no-unbound/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
           }
           for relpath, keys in required.items():
               path = Path(relpath)
@@ -168,5 +169,5 @@ jobs:
 
       - name: Validate default container image matrix
         run: |
-          python scripts/default-container-images.py --github-matrix
+          python -m unittest discover -s tests -p 'test_*.py'
           python scripts/validate-secure-defaults.py

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Run all discovered Molecule scenarios in `molecule/*` (or pass a subset):
 ```bash
 ./scripts/molecule-test-all
 ./scripts/molecule-test-all ubuntu ubuntu-26.04
+./scripts/molecule-test-all pihole-no-unbound
 ./scripts/molecule-test-all --ubuntu-only
 VAGRANT_DEFAULT_PROVIDER=libvirt ./scripts/molecule-test-all
 ./scripts/molecule-test-all --list
@@ -329,6 +330,8 @@ VAGRANT_DEFAULT_PROVIDER=libvirt ./scripts/molecule-test-all
 Like `scripts/molecule-vagrant`, this helper auto-selects
 `MOLECULE_VAGRANT_INVENTORY` from `VAGRANT_DEFAULT_PROVIDER` when unset
 (`vagrant.yml` for VirtualBox, `vagrant_libvirt.yml` for libvirt/kvm).
+It also selects the corresponding one-host inventory for the
+`pihole-no-unbound` scenario.
 
 For Vagrant/Molecule inventories (`vagrant_env: true`), roles skip disruptive
 reboots after hostname and package-update changes to avoid long guest-network
@@ -357,6 +360,14 @@ container image; image scans are report-only because those findings belong to
 upstream images we do not build in this repository. Image targets are derived
 from role defaults by `scripts/default-container-images.py`, so changing a
 default pin updates the scan matrix without duplicating image names.
+The scheduled weekly scan keeps upstream findings visible for periodic triage;
+persistent Critical findings should trigger a pinned-image upgrade review.
+
+The dedicated `pihole-no-unbound` Molecule scenario deploys the real Docker and
+Pi-hole roles with public upstream resolvers, then proves Pi-hole resolves DNS
+without an Unbound container or shared Unbound network. Hosted CI also unit
+tests the default-image matrix so malformed, empty, or incomplete scan targets
+fail before Trivy jobs are created.
 
 ## Operational docs
 

--- a/inventory/vagrant_no_unbound.yml
+++ b/inventory/vagrant_no_unbound.yml
@@ -1,0 +1,33 @@
+---
+all:
+  hosts:
+    pihole-no-unbound:
+      ansible_host: 192.168.56.6
+      ansible_port: 22
+  vars:
+    ansible_user: vagrant
+    ansible_password: vagrant
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    vagrant_env: true
+    pihole_enable_unbound: false
+    pihole_upstream_resolvers:
+      - "1.1.1.1"
+      - "1.0.0.1"
+    pihole_environment_variables:
+      TZ: Europe/London
+      FTLCONF_webserver_api_password: "LabOnly-No-Unbound-Password!"
+      FTLCONF_dns_listeningMode: "all"
+      DHCP_ACTIVE: false
+      REV_SERVER: false
+    pihole_compose_dir: /opt/pihole
+    pihole_network_name: dns_net
+    unbound_container_name: unbound
+    docker_group_users:
+      - vagrant
+    docker_daemon_dns:
+      - "1.1.1.1"
+      - "8.8.8.8"
+    pihole_docker_dns:
+      - "1.1.1.1"
+      - "8.8.8.8"

--- a/inventory/vagrant_no_unbound_libvirt.yml
+++ b/inventory/vagrant_no_unbound_libvirt.yml
@@ -1,0 +1,33 @@
+---
+all:
+  hosts:
+    pihole-no-unbound:
+      ansible_host: 192.168.121.6
+      ansible_port: 22
+  vars:
+    ansible_user: vagrant
+    ansible_password: vagrant
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    vagrant_env: true
+    pihole_enable_unbound: false
+    pihole_upstream_resolvers:
+      - "1.1.1.1"
+      - "1.0.0.1"
+    pihole_environment_variables:
+      TZ: Europe/London
+      FTLCONF_webserver_api_password: "LabOnly-No-Unbound-Password!"
+      FTLCONF_dns_listeningMode: "all"
+      DHCP_ACTIVE: false
+      REV_SERVER: false
+    pihole_compose_dir: /opt/pihole
+    pihole_network_name: dns_net
+    unbound_container_name: unbound
+    docker_group_users:
+      - vagrant
+    docker_daemon_dns:
+      - "1.1.1.1"
+      - "8.8.8.8"
+    pihole_docker_dns:
+      - "1.1.1.1"
+      - "8.8.8.8"

--- a/molecule/pihole-no-unbound/Vagrantfile
+++ b/molecule/pihole-no-unbound/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.define "pihole-no-unbound" do |node|
+    node.vm.hostname         = "pihole-no-unbound"
+    node.vm.box              = "bento/ubuntu-24.04"
+    node.vm.box_check_update = false
+
+    node.vm.provider "virtualbox" do |v, override|
+      v.memory = 2048
+      v.cpus   = 2
+      override.vm.network "private_network",
+                          ip: "192.168.56.6",
+                          netmask: "255.255.255.0",
+                          auto_config: true
+    end
+
+    if Vagrant.has_plugin?("vagrant-libvirt")
+      node.vm.provider "libvirt" do |l, override|
+        l.memory = 2048
+        l.cpus   = 2
+        l.driver = "kvm"
+        override.vm.network "private_network",
+                            ip: "192.168.121.6",
+                            netmask: "255.255.255.0",
+                            auto_config: true,
+                            libvirt__network_name: "vagrant-56",
+                            libvirt__mgmt_network: "none"
+      end
+    end
+  end
+end

--- a/molecule/pihole-no-unbound/converge.yml
+++ b/molecule/pihole-no-unbound/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge Pi-hole without Unbound
+  hosts: all
+  become: true
+  roles:
+    - role: steveyminecraft.pihole.docker
+    - role: steveyminecraft.pihole.pihole

--- a/molecule/pihole-no-unbound/create.yml
+++ b/molecule/pihole-no-unbound/create.yml
@@ -1,0 +1,11 @@
+---
+- name: Create test platform
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Start Vagrant environment for this scenario
+      ansible.builtin.command: vagrant up
+      args:
+        chdir: "{{ playbook_dir }}"
+      changed_when: true

--- a/molecule/pihole-no-unbound/destroy.yml
+++ b/molecule/pihole-no-unbound/destroy.yml
@@ -1,0 +1,11 @@
+---
+- name: Destroy test platform
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Destroy Vagrant environment for this scenario
+      ansible.builtin.command: vagrant destroy -f
+      args:
+        chdir: "{{ playbook_dir }}"
+      changed_when: true

--- a/molecule/pihole-no-unbound/molecule.yml
+++ b/molecule/pihole-no-unbound/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: shell
+  command: ${MOLECULE_PROJECT_DIRECTORY}/scripts/install-ansible-collections.sh
+driver:
+  name: vagrant
+platforms:
+  - name: pihole-no-unbound
+    box: "bento/ubuntu-24.04"
+    hostname: pihole-no-unbound
+    memory: 2048
+    cpus: 2
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+    ansible_password: vagrant
+    ansible_become: true
+  inventory:
+    links:
+      hosts: ../../inventory/${MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY:-vagrant_no_unbound.yml}
+  playbooks:
+    create: create.yml
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+    destroy: destroy.yml
+  env:
+    ANSIBLE_INJECT_FACTS_AS_VARS: "false"
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+    ANSIBLE_COLLECTIONS_PATH: ${MOLECULE_PROJECT_DIRECTORY}/collections:${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections
+verifier:
+  name: ansible
+scenario:
+  name: pihole-no-unbound
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/molecule/pihole-no-unbound/prepare.yml
+++ b/molecule/pihole-no-unbound/prepare.yml
@@ -1,0 +1,3 @@
+---
+- name: Molecule prepare
+  import_playbook: ../common/prepare.yml

--- a/molecule/pihole-no-unbound/verify.yml
+++ b/molecule/pihole-no-unbound/verify.yml
@@ -1,0 +1,54 @@
+---
+- name: Verify Pi-hole-only deployment
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Inspect Pi-hole container
+      community.docker.docker_container_info:
+        name: "{{ pihole_container_name | default('pihole') }}"
+      register: pihole_no_unbound_container
+
+    - name: Inspect Unbound container
+      community.docker.docker_container_info:
+        name: "{{ unbound_container_name | default('unbound') }}"
+      register: pihole_no_unbound_unbound
+
+    - name: Inspect Unbound shared network
+      community.docker.docker_network_info:
+        name: "{{ pihole_network_name | default('dns_net') }}"
+      register: pihole_no_unbound_network
+
+    - name: Read rendered Pi-hole Compose configuration
+      ansible.builtin.slurp:
+        src: "{{ pihole_compose_file | default((pihole_compose_dir | default('/opt/pihole')) ~ '/docker-compose.yml') }}"
+      register: pihole_no_unbound_compose_file
+
+    - name: Parse rendered Pi-hole Compose configuration
+      ansible.builtin.set_fact:
+        pihole_no_unbound_compose: >-
+          {{ pihole_no_unbound_compose_file.content | b64decode | from_yaml }}
+
+    - name: Resolve external DNS through Pi-hole
+      ansible.builtin.command:
+        argv:
+          - dig
+          - +short
+          - "@127.0.0.1"
+          - cloudflare.com
+      register: pihole_no_unbound_dns
+      changed_when: false
+
+    - name: Assert Pi-hole-only deployment is healthy
+      ansible.builtin.assert:
+        that:
+          - pihole_no_unbound_container.exists
+          - pihole_no_unbound_container.container.State.Running
+          - not pihole_no_unbound_unbound.exists
+          - not pihole_no_unbound_network.exists
+          - pihole_no_unbound_compose.networks is not defined
+          - pihole_no_unbound_compose.services.pihole.networks is not defined
+          - >-
+            'FTLCONF_dns_upstreams=1.1.1.1;1.0.0.1'
+            in pihole_no_unbound_compose.services.pihole.environment
+          - pihole_no_unbound_dns.stdout | trim | length > 0

--- a/scripts/molecule-test-all
+++ b/scripts/molecule-test-all
@@ -16,9 +16,11 @@ sync_inventory_from_provider() {
   case "${VAGRANT_DEFAULT_PROVIDER:-virtualbox}" in
     libvirt|kvm)
       export MOLECULE_VAGRANT_INVENTORY="${MOLECULE_VAGRANT_INVENTORY:-vagrant_libvirt.yml}"
+      export MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY="${MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY:-vagrant_no_unbound_libvirt.yml}"
       ;;
     *)
       export MOLECULE_VAGRANT_INVENTORY="${MOLECULE_VAGRANT_INVENTORY:-vagrant.yml}"
+      export MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY="${MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY:-vagrant_no_unbound.yml}"
       ;;
   esac
 }
@@ -143,6 +145,7 @@ sync_inventory_from_provider
 echo "Repo: $repo_root"
 echo "Provider: ${VAGRANT_DEFAULT_PROVIDER:-virtualbox}"
 echo "Inventory: ${MOLECULE_VAGRANT_INVENTORY}"
+echo "Pi-hole-only inventory: ${MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY}"
 echo "Scenarios: ${selected[*]}"
 echo ""
 

--- a/scripts/molecule-vagrant
+++ b/scripts/molecule-vagrant
@@ -16,9 +16,11 @@ sync_inventory_from_provider() {
   case "${VAGRANT_DEFAULT_PROVIDER:-virtualbox}" in
     libvirt|kvm)
       export MOLECULE_VAGRANT_INVENTORY="${MOLECULE_VAGRANT_INVENTORY:-vagrant_libvirt.yml}"
+      export MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY="${MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY:-vagrant_no_unbound_libvirt.yml}"
       ;;
     *)
       export MOLECULE_VAGRANT_INVENTORY="${MOLECULE_VAGRANT_INVENTORY:-vagrant.yml}"
+      export MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY="${MOLECULE_VAGRANT_NO_UNBOUND_INVENTORY:-vagrant_no_unbound.yml}"
       ;;
   esac
 }

--- a/tests/test_default_container_images.py
+++ b/tests/test_default_container_images.py
@@ -1,0 +1,65 @@
+"""Tests for the default container image scan matrix."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "default-container-images.py"
+
+
+def load_helper():
+    spec = importlib.util.spec_from_file_location("default_container_images", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DefaultContainerImagesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.helper = load_helper()
+
+    def test_default_images_include_each_deployed_service(self) -> None:
+        images = set(self.helper.default_images())
+        pihole = self.helper.load_defaults("pihole")
+        unbound = self.helper.load_defaults("unbound")
+        nebula = self.helper.load_defaults("nebula_sync")
+
+        self.assertIn(pihole["pihole_image"], images)
+        self.assertIn(unbound["unbound_image_arch_default"], images)
+        self.assertTrue(set(unbound["unbound_image_arch_map"].values()) <= images)
+        self.assertIn(
+            f"{nebula['nebula_sync_image']}:{nebula['nebula_sync_image_tag']}",
+            images,
+        )
+
+    def test_github_matrix_is_valid_and_has_unique_keys(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--github-matrix"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        matrix = json.loads(result.stdout)
+        entries = matrix["include"]
+
+        self.assertGreaterEqual(len(entries), 3)
+        self.assertEqual(len(entries), len(self.helper.default_images()))
+        self.assertEqual(len({entry["key"] for entry in entries}), len(entries))
+        self.assertEqual(
+            {entry["image"] for entry in entries},
+            set(self.helper.default_images()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Promote the latest tested `dev` changes into `master`.

This promotion adds:

- dedicated Pi-hole-only/no-Unbound Molecule coverage
- verification that Pi-hole resolves external DNS without an Unbound container or shared network
- unit validation for the default container-image scan matrix
- documentation for image-scan triage and the new test scenario

## Validation

Post-merge actions for `dev` commit `b077012` are green:

- CI - Ansible-Pihole Checks
- Security scanning
- Automatic Dependency Submission

The maintainer also ran the full Molecule suite successfully before promotion.

## Release workflow

Merging this PR promotes `dev` into `master`. Release Please will then manage
the release PR, version bump, tag, GitHub release, and Galaxy publication.
