### PR TITLE
[codex] Promote dev to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ services during each converge.
 | `ubuntu-26.04` | [`molecule/ubuntu-26.04/`](molecule/ubuntu-26.04/) | Ubuntu 26.04 — VirtualBox: `konstruktoid/ubuntu-26.04` (Bento); libvirt: `cloud-image/ubuntu-26.04` |
 | `default` | [`molecule/default/`](molecule/default/) | Rocky-style box (see `molecule.yml`) |
 | `nebula-sync-migration` | [`molecule/nebula-sync-migration/`](molecule/nebula-sync-migration/) | Seeds legacy plaintext credentials, then verifies migration to secret-file mode |
+| `pihole-no-unbound` | [`molecule/pihole-no-unbound/`](molecule/pihole-no-unbound/) | Runs bootstrap and update workflows with Pi-hole-only DNS |
 
 Examples:
 
@@ -363,11 +364,12 @@ default pin updates the scan matrix without duplicating image names.
 The scheduled weekly scan keeps upstream findings visible for periodic triage;
 persistent Critical findings should trigger a pinned-image upgrade review.
 
-The dedicated `pihole-no-unbound` Molecule scenario deploys the real Docker and
-Pi-hole roles with public upstream resolvers, then proves Pi-hole resolves DNS
-without an Unbound container or shared Unbound network. Hosted CI also unit
-tests the default-image matrix so malformed, empty, or incomplete scan targets
-fail before Trivy jobs are created.
+The dedicated `pihole-no-unbound` Molecule scenario runs the real bootstrap and
+update playbooks with public upstream resolvers, then proves Pi-hole resolves
+DNS without an Unbound container, shared Unbound network, or Unbound health
+check dependency. Hosted CI also unit tests the default-image matrix so
+malformed, empty, or incomplete scan targets fail before Trivy jobs are
+created.
 
 ## Operational docs
 

--- a/inventory/vagrant_no_unbound.yml
+++ b/inventory/vagrant_no_unbound.yml
@@ -4,12 +4,20 @@ all:
     pihole-no-unbound:
       ansible_host: 192.168.56.6
       ansible_port: 22
+      priority: 100
+      keepalive_role: MASTER
   vars:
     ansible_user: vagrant
     ansible_password: vagrant
+    ansible_user_home_dir: /home/vagrant
     ansible_python_interpreter: /usr/bin/python3
     ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    github_user_for_ssh_key: steveyminecraft
+    password_lock: false
+    timezone: Europe/London
     vagrant_env: true
+    pihole_ha_mode: false
+    pihole_vip_ipv4: 192.168.56.7/24
     pihole_enable_unbound: false
     pihole_upstream_resolvers:
       - "1.1.1.1"

--- a/inventory/vagrant_no_unbound_libvirt.yml
+++ b/inventory/vagrant_no_unbound_libvirt.yml
@@ -4,12 +4,20 @@ all:
     pihole-no-unbound:
       ansible_host: 192.168.121.6
       ansible_port: 22
+      priority: 100
+      keepalive_role: MASTER
   vars:
     ansible_user: vagrant
     ansible_password: vagrant
+    ansible_user_home_dir: /home/vagrant
     ansible_python_interpreter: /usr/bin/python3
     ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    github_user_for_ssh_key: steveyminecraft
+    password_lock: false
+    timezone: Europe/London
     vagrant_env: true
+    pihole_ha_mode: false
+    pihole_vip_ipv4: 192.168.121.7/24
     pihole_enable_unbound: false
     pihole_upstream_resolvers:
       - "1.1.1.1"

--- a/molecule/pihole-no-unbound/converge.yml
+++ b/molecule/pihole-no-unbound/converge.yml
@@ -1,7 +1,3 @@
 ---
-- name: Converge Pi-hole without Unbound
-  hosts: all
-  become: true
-  roles:
-    - role: steveyminecraft.pihole.docker
-    - role: steveyminecraft.pihole.pihole
+- name: Converge Pi-hole without Unbound through bootstrap workflow
+  import_playbook: ../../playbooks/bootstrap-pihole.yaml

--- a/molecule/pihole-no-unbound/molecule.yml
+++ b/molecule/pihole-no-unbound/molecule.yml
@@ -23,6 +23,7 @@ provisioner:
     create: create.yml
     prepare: prepare.yml
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
     destroy: destroy.yml
   env:
@@ -39,5 +40,6 @@ scenario:
     - create
     - prepare
     - converge
+    - side_effect
     - verify
     - destroy

--- a/molecule/pihole-no-unbound/side_effect.yml
+++ b/molecule/pihole-no-unbound/side_effect.yml
@@ -1,0 +1,3 @@
+---
+- name: Exercise Pi-hole-only update workflow
+  import_playbook: ../../playbooks/update-pihole.yaml


### PR DESCRIPTION
## Summary
- promote the completed Pi-hole-only functional coverage from `dev` to `master`
- run the no-Unbound Molecule scenario through the real bootstrap and update playbooks
- verify those production workflows skip Unbound deployment and health checks when disabled

## Included work
- #103

## Validation
- full `molecule test -s pihole-no-unbound`
- repository-wide `ansible-lint -p roles playbooks molecule`
- YAML lint, Ansible syntax checks, secure-default validation, and unit tests