### PR TITLE
fix: complete release readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,11 @@ The scheduled weekly scan keeps upstream findings visible for periodic triage;
 persistent Critical findings should trigger a pinned-image upgrade review.
 
 The dedicated `pihole-no-unbound` Molecule scenario runs the real bootstrap and
-update playbooks with public upstream resolvers, then proves Pi-hole resolves
-DNS without an Unbound container, shared Unbound network, or Unbound health
-check dependency. Hosted CI also unit tests the default-image matrix so
-malformed, empty, or incomplete scan targets fail before Trivy jobs are
-created.
+update playbooks with public upstream resolvers. It verifies after each
+workflow that Pi-hole resolves DNS without an Unbound container, shared Unbound
+network, or Unbound health check dependency. Hosted CI also unit tests the
+default-image matrix so malformed, empty, incomplete, or floating `latest` scan
+targets fail before Trivy jobs are created.
 
 ## Operational docs
 
@@ -402,13 +402,13 @@ Use conventional commits on PRs (`feat:`, `fix:`, etc.) so release-please can ch
 
 Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
 
-**Install a specific version** (replace `<version>` with a release from the links below):
+**Install a specific version**:
 
 ```bash
-ansible-galaxy collection install steveyminecraft.pihole:==<version>
+ansible-galaxy collection install steveyminecraft.pihole:==1.2.4
 ```
 
-Replace `<version>` with a published release such as `1.2.3`.
+Replace `1.2.4` with another published release when required.
 
 See [GitHub releases](https://github.com/steveyminecraft/ansible-pihole/releases) and [`CHANGELOG.md`](CHANGELOG.md) for version history.
 

--- a/molecule/pihole-no-unbound/molecule.yml
+++ b/molecule/pihole-no-unbound/molecule.yml
@@ -40,6 +40,7 @@ scenario:
     - create
     - prepare
     - converge
+    - verify
     - side_effect
     - verify
     - destroy

--- a/tests/test_default_container_images.py
+++ b/tests/test_default_container_images.py
@@ -42,6 +42,13 @@ class DefaultContainerImagesTests(unittest.TestCase):
             images,
         )
 
+    def test_default_images_reject_latest_tag(self) -> None:
+        latest_images = [
+            image for image in self.helper.default_images() if image.endswith(":latest")
+        ]
+
+        self.assertEqual([], latest_images)
+
     def test_github_matrix_is_valid_and_has_unique_keys(self) -> None:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--github-matrix"],


### PR DESCRIPTION
## Summary
- fix the README specific-version install example so the version no longer disappears when rendered
- reject floating `:latest` tags in the default runtime image matrix tests
- verify the no-Unbound deployment after bootstrap and again after the update workflow

## Release impact
This conventional `fix:` change prepares a patch release after promotion from `dev` to `master`. Release-please should open the next release PR after that promotion.

## Validation
- full `molecule test -s pihole-no-unbound` with both verify phases passing
- `ansible-lint -p roles playbooks molecule`
- YAML lint, support-policy validation, secure-default validation, and unit tests