### PR TITLE
feat: add remote functional test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
         run: |
           ansible --version
           ansible-lint --version
-          ansible-lint -p roles playbooks molecule
+          ansible-lint -p roles playbooks molecule tests/remote/verify
 
       - name: YAML lint
-        run: yamllint roles playbooks molecule inventory
+        run: yamllint roles playbooks molecule inventory tests/remote/inventories tests/remote/verify
 
   ansible-tests-ubuntu:
     name: Ansible syntax & dry-run (${{ matrix.runner }} / Python ${{ matrix.python-version }} / Core ${{ matrix.ansible-core }})
@@ -140,7 +140,7 @@ jobs:
 
       - name: Validate workflow and project YAML formatting
         run: |
-          yamllint .github/workflows molecule inventory playbooks roles
+          yamllint .github/workflows molecule inventory playbooks roles tests/remote/inventories tests/remote/verify
 
       - name: Validate Ansible Core support policy
         run: python scripts/check-ansible-version-policy.py

--- a/README.md
+++ b/README.md
@@ -257,9 +257,17 @@ services during each converge.
 
 - Molecule, Ansible, Vagrant, and **VirtualBox** or **libvirt** (`vagrant-libvirt`) as appropriate.
 - Run Molecule from the **repository root** so paths and inventory links resolve.
-- **Lint:** CI runs [ansible-lint](https://ansible-lint.readthedocs.io/) on `roles`, `playbooks`, and `molecule`; [yamllint](https://yamllint.readthedocs.io/) includes `molecule/`.
+- **Lint:** CI runs [ansible-lint](https://ansible-lint.readthedocs.io/) on
+  roles, playbooks, Molecule, and remote verification playbooks;
+  [yamllint](https://yamllint.readthedocs.io/) covers their YAML inventories and
+  configuration.
 - Full `molecule test` with Vagrant providers is intended for local or self-hosted
   environments where Vagrant + provider support is guaranteed.
+
+Provider-neutral remote functional tests live under
+[`tests/remote/`](tests/remote/). They run the production bootstrap/update
+playbooks and reusable verification against externally provisioned AWS
+instances, lab VMs, or Raspberry Pi hardware.
 
 ### Scenarios
 

--- a/tests/remote/README.md
+++ b/tests/remote/README.md
@@ -1,0 +1,40 @@
+# Remote functional tests
+
+This harness runs the production playbooks and reusable verification playbooks
+against externally provisioned AWS instances, lab VMs, or Raspberry Pi
+hardware.
+
+The repository does not assume ownership of remote hosts. Set optional
+lifecycle hooks when a test environment can be created, checked for
+idempotence, or reset automatically:
+
+```bash
+export REMOTE_CREATE_COMMAND='./path/to/create-test-hosts'
+export REMOTE_IDEMPOTENCE_COMMAND='ansible-playbook -i inventory.yml playbooks/bootstrap-pihole.yaml --check'
+export REMOTE_RESET_COMMAND='./path/to/reset-test-hosts'
+```
+
+Run a scenario from the repository root:
+
+```bash
+tests/remote/run.sh \
+  --inventory tests/remote/inventories/example-no-unbound.yml \
+  --scenario no-unbound
+```
+
+| Scenario | Verification |
+|----------|--------------|
+| `single` | Pi-hole and Unbound containers plus local DNS |
+| `no-unbound` | Pi-hole DNS, explicit upstreams, and no Unbound resources |
+| `ha` | Pi-hole, Unbound, keepalived, VIP DNS, and optional Nebula Sync placement |
+
+Copy an example inventory outside the repository and replace all placeholder
+addresses and credentials. Never commit production credentials.
+
+The harness verifies immediately after bootstrap and again after exercising the
+update playbook. Use `--skip-converge` to verify an existing deployment or
+`--skip-update` when the environment must not be updated.
+
+Idempotence is an explicit hook because the current HA bootstrap workflow
+intentionally drains and resumes services. Environments that require a strict
+zero-change assertion should provide a topology-specific command.

--- a/tests/remote/inventories/example-aws.yml
+++ b/tests/remote/inventories/example-aws.yml
@@ -1,0 +1,23 @@
+---
+all:
+  hosts:
+    aws-pihole-01:
+      ansible_host: 203.0.113.10
+      priority: 100
+      keepalive_role: MASTER
+  vars:
+    ansible_user: ubuntu
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_user_home_dir: /home/ubuntu
+    github_user_for_ssh_key: replace-me
+    password_lock: true
+    timezone: Etc/UTC
+    pihole_enable_unbound: true
+    pihole_ha_mode: false
+    pihole_vip_ipv4: 203.0.113.53/24
+    pihole_environment_variables:
+      TZ: Etc/UTC
+      FTLCONF_webserver_api_password: REPLACE_WITH_ANSIBLE_VAULT
+      FTLCONF_dns_listeningMode: all
+      DHCP_ACTIVE: false
+      REV_SERVER: false

--- a/tests/remote/inventories/example-lab-ha.yml
+++ b/tests/remote/inventories/example-lab-ha.yml
@@ -1,0 +1,36 @@
+---
+all:
+  hosts:
+    lab-pihole-01:
+      ansible_host: 192.0.2.10
+      priority: 110
+      keepalive_role: MASTER
+    lab-pihole-02:
+      ansible_host: 192.0.2.11
+      priority: 100
+      keepalive_role: BACKUP
+  children:
+    nebula_sync_controller:
+      hosts:
+        lab-pihole-01:
+  vars:
+    ansible_user: ansible
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_user_home_dir: /home/ansible
+    github_user_for_ssh_key: replace-me
+    password_lock: true
+    timezone: Etc/UTC
+    pihole_enable_unbound: true
+    pihole_ha_mode: true
+    pihole_vip_ipv4: 192.0.2.53/24
+    pihole_environment_variables:
+      TZ: Etc/UTC
+      FTLCONF_webserver_api_password: REPLACE_WITH_ANSIBLE_VAULT
+      FTLCONF_dns_listeningMode: all
+      DHCP_ACTIVE: false
+      REV_SERVER: false
+    nebula_sync_primary_url: http://192.0.2.10
+    nebula_sync_primary_password: REPLACE_WITH_ANSIBLE_VAULT
+    nebula_sync_replicas:
+      - url: http://192.0.2.11
+        password: REPLACE_WITH_ANSIBLE_VAULT

--- a/tests/remote/inventories/example-no-unbound.yml
+++ b/tests/remote/inventories/example-no-unbound.yml
@@ -1,0 +1,26 @@
+---
+all:
+  hosts:
+    pihole-only-01:
+      ansible_host: 192.0.2.20
+      priority: 100
+      keepalive_role: MASTER
+  vars:
+    ansible_user: ansible
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_user_home_dir: /home/ansible
+    github_user_for_ssh_key: replace-me
+    password_lock: true
+    timezone: Etc/UTC
+    pihole_enable_unbound: false
+    pihole_ha_mode: false
+    pihole_vip_ipv4: 192.0.2.21/24
+    pihole_upstream_resolvers:
+      - 1.1.1.1
+      - 1.0.0.1
+    pihole_environment_variables:
+      TZ: Etc/UTC
+      FTLCONF_webserver_api_password: REPLACE_WITH_ANSIBLE_VAULT
+      FTLCONF_dns_listeningMode: all
+      DHCP_ACTIVE: false
+      REV_SERVER: false

--- a/tests/remote/inventories/example-pi.yml
+++ b/tests/remote/inventories/example-pi.yml
@@ -1,0 +1,24 @@
+---
+all:
+  hosts:
+    raspberry-pi:
+      ansible_host: 192.0.2.30
+      priority: 100
+      keepalive_role: MASTER
+  vars:
+    ansible_user: pi
+    ansible_python_interpreter: /usr/bin/python3
+    ansible_user_home_dir: /home/pi
+    github_user_for_ssh_key: replace-me
+    password_lock: true
+    timezone: Etc/UTC
+    pihole_enable_unbound: true
+    pihole_ha_mode: false
+    pihole_vip_ipv4: 192.0.2.31/24
+    static_dns: 1.1.1.1
+    pihole_environment_variables:
+      TZ: Etc/UTC
+      FTLCONF_webserver_api_password: REPLACE_WITH_ANSIBLE_VAULT
+      FTLCONF_dns_listeningMode: all
+      DHCP_ACTIVE: false
+      REV_SERVER: false

--- a/tests/remote/run.sh
+++ b/tests/remote/run.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+inventory=""
+scenario=""
+skip_converge=false
+skip_update=false
+
+usage() {
+  cat <<'EOF'
+Usage: tests/remote/run.sh --inventory PATH --scenario SCENARIO [options]
+
+Scenarios:
+  single       Pi-hole with Unbound on independent nodes
+  no-unbound   Pi-hole with explicit upstream resolvers and no Unbound
+  ha           Pi-hole, Unbound, keepalived VIP, and optional Nebula Sync
+
+Options:
+  --skip-converge  Verify an existing deployment without bootstrapping it.
+  --skip-update    Do not exercise playbooks/update-pihole.yaml.
+  -h, --help       Show this help.
+
+Optional lifecycle hooks:
+  REMOTE_CREATE_COMMAND       Provision or start hosts before converge.
+  REMOTE_IDEMPOTENCE_COMMAND  Run an environment-specific idempotence check.
+  REMOTE_RESET_COMMAND        Reset or destroy hosts after verification.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inventory)
+      inventory="${2:-}"
+      shift 2
+      ;;
+    --scenario)
+      scenario="${2:-}"
+      shift 2
+      ;;
+    --skip-converge)
+      skip_converge=true
+      shift
+      ;;
+    --skip-update)
+      skip_update=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$inventory" || -z "$scenario" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$inventory" ]]; then
+  echo "Inventory not found: $inventory" >&2
+  exit 2
+fi
+
+case "$scenario" in
+  single)
+    verify_playbooks=(pihole.yml unbound.yml)
+    ;;
+  no-unbound)
+    verify_playbooks=(pihole.yml no-unbound.yml)
+    ;;
+  ha)
+    verify_playbooks=(pihole.yml unbound.yml keepalived.yml vip-dns.yml nebula-sync.yml)
+    ;;
+  *)
+    echo "Unknown scenario: $scenario" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+run_hook() {
+  local name="$1"
+  local command="$2"
+
+  if [[ -z "$command" ]]; then
+    echo "Skipping optional $name hook."
+    return
+  fi
+
+  echo "Running $name hook."
+  /bin/bash -lc "$command"
+}
+
+run_verification() {
+  local playbook
+
+  for playbook in "${verify_playbooks[@]}"; do
+    echo "Running remote verification: $playbook"
+    ansible-playbook -i "$inventory" "tests/remote/verify/$playbook"
+  done
+}
+
+cleanup() {
+  run_hook reset "${REMOTE_RESET_COMMAND:-}"
+}
+trap cleanup EXIT
+
+run_hook create "${REMOTE_CREATE_COMMAND:-}"
+
+echo "Validating inventory: $inventory"
+ansible-inventory -i "$inventory" --graph
+
+if ! $skip_converge; then
+  echo "Converging remote deployment."
+  ansible-playbook -i "$inventory" playbooks/bootstrap-pihole.yaml
+  run_verification
+fi
+
+run_hook idempotence "${REMOTE_IDEMPOTENCE_COMMAND:-}"
+
+if ! $skip_update; then
+  echo "Exercising remote update workflow."
+  ansible-playbook -i "$inventory" playbooks/update-pihole.yaml
+fi
+
+run_verification
+
+echo "Remote scenario passed: $scenario"

--- a/tests/remote/verify/keepalived.yml
+++ b/tests/remote/verify/keepalived.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify remote keepalived deployment
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert keepalived is running
+      ansible.builtin.assert:
+        that:
+          - "'keepalived.service' in ansible_facts.services"
+          - ansible_facts.services['keepalived.service'].state == 'running'

--- a/tests/remote/verify/nebula-sync.yml
+++ b/tests/remote/verify/nebula-sync.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify remote Nebula Sync placement
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    remote_nebula_controller: >-
+      {{ (groups['nebula_sync_controller'] | default([]) | first) | default('') }}
+  tasks:
+    - name: Inspect Nebula Sync container
+      community.docker.docker_container_info:
+        name: "{{ nebula_sync_container_name | default('nebula') }}"
+      register: remote_nebula_container
+      when: remote_nebula_controller | length > 0
+
+    - name: Assert Nebula Sync runs only on its controller
+      ansible.builtin.assert:
+        that:
+          - >-
+            (inventory_hostname == remote_nebula_controller
+             and remote_nebula_container.exists
+             and remote_nebula_container.container.State.Running)
+            or
+            (inventory_hostname != remote_nebula_controller
+             and not remote_nebula_container.exists)
+      when: remote_nebula_controller | length > 0

--- a/tests/remote/verify/no-unbound.yml
+++ b/tests/remote/verify/no-unbound.yml
@@ -1,0 +1,37 @@
+---
+- name: Verify remote Pi-hole-only deployment
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Inspect Unbound container
+      community.docker.docker_container_info:
+        name: "{{ unbound_container_name | default('unbound') }}"
+      register: remote_no_unbound_container
+
+    - name: Inspect Unbound shared network
+      community.docker.docker_network_info:
+        name: "{{ pihole_network_name | default('dns_net') }}"
+      register: remote_no_unbound_network
+
+    - name: Read rendered Pi-hole Compose configuration
+      ansible.builtin.slurp:
+        src: "{{ pihole_compose_file | default((pihole_compose_dir | default('/opt/pihole')) ~ '/docker-compose.yml') }}"
+      register: remote_no_unbound_compose_file
+
+    - name: Parse rendered Pi-hole Compose configuration
+      ansible.builtin.set_fact:
+        remote_no_unbound_compose: >-
+          {{ remote_no_unbound_compose_file.content | b64decode | from_yaml }}
+
+    - name: Assert Unbound resources are absent
+      ansible.builtin.assert:
+        that:
+          - not remote_no_unbound_container.exists
+          - not remote_no_unbound_network.exists
+          - remote_no_unbound_compose.networks is not defined
+          - remote_no_unbound_compose.services.pihole.networks is not defined
+          - remote_no_unbound_compose.services.pihole.environment
+            | select('match', '^FTLCONF_dns_upstreams=.+')
+            | list
+            | length == 1

--- a/tests/remote/verify/pihole.yml
+++ b/tests/remote/verify/pihole.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify remote Pi-hole deployment
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Inspect Pi-hole container
+      community.docker.docker_container_info:
+        name: "{{ pihole_container_name | default('pihole') }}"
+      register: remote_pihole_container
+
+    - name: Resolve external DNS through local Pi-hole
+      ansible.builtin.command:
+        argv:
+          - dig
+          - +short
+          - "@127.0.0.1"
+          - "{{ remote_test_dns_qname | default('cloudflare.com') }}"
+      register: remote_pihole_dns
+      changed_when: false
+
+    - name: Assert remote Pi-hole is healthy
+      ansible.builtin.assert:
+        that:
+          - remote_pihole_container.exists
+          - remote_pihole_container.container.State.Running
+          - remote_pihole_dns.stdout | trim | length > 0

--- a/tests/remote/verify/unbound.yml
+++ b/tests/remote/verify/unbound.yml
@@ -1,0 +1,32 @@
+---
+- name: Verify remote Unbound deployment
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Inspect Unbound container
+      community.docker.docker_container_info:
+        name: "{{ unbound_container_name | default('unbound') }}"
+      register: remote_unbound_container
+
+    - name: Resolve DNS directly through Unbound from Pi-hole container
+      ansible.builtin.command:
+        argv:
+          - docker
+          - exec
+          - "{{ pihole_container_name | default('pihole') }}"
+          - dig
+          - +short
+          - "@{{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}"
+          - -p
+          - "{{ unbound_port | default(5335) | string }}"
+          - "{{ remote_test_dns_qname | default('cloudflare.com') }}"
+      register: remote_unbound_dns
+      changed_when: false
+
+    - name: Assert remote Unbound is healthy
+      ansible.builtin.assert:
+        that:
+          - remote_unbound_container.exists
+          - remote_unbound_container.container.State.Running
+          - remote_unbound_dns.stdout | trim | length > 0

--- a/tests/remote/verify/vip-dns.yml
+++ b/tests/remote/verify/vip-dns.yml
@@ -1,0 +1,22 @@
+---
+- name: Verify remote VIP DNS
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Resolve DNS through the Pi-hole VIP
+      ansible.builtin.command:
+        argv:
+          - dig
+          - +short
+          - "@{{ (pihole_vip_ipv4 | split('/'))[0] }}"
+          - "{{ remote_test_dns_qname | default('cloudflare.com') }}"
+      register: remote_vip_dns
+      changed_when: false
+      run_once: true
+
+    - name: Assert VIP DNS is healthy
+      ansible.builtin.assert:
+        that:
+          - remote_vip_dns.stdout | trim | length > 0
+      run_once: true


### PR DESCRIPTION
## Summary
- add a provider-neutral remote test runner for AWS, lab VM, and Raspberry Pi inventories
- add reusable verification playbooks for Pi-hole, Unbound/no-Unbound, keepalived, VIP DNS, and Nebula Sync placement
- verify after bootstrap and again after update, with optional create/idempotence/reset hooks
- include remote verifier files in hosted lint coverage

## Validation
- all example inventories parse and syntax-check production bootstrap/update playbooks
- all remote verifier playbooks pass syntax checks and production ansible-lint
- repository YAML lint and secure-default validation
- runner shell syntax and help path