### PR TITLE
[codex] Keep README version example aligned with releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
 ansible-galaxy collection install steveyminecraft.pihole:==VERSION
 ```
 
-Replace `VERSION` with the published release required, for example `1.2.5`.
+Replace `VERSION` with the published release required, for example `1.2.5`. <!-- x-release-please-version -->
 
 See [GitHub releases](https://github.com/steveyminecraft/ansible-pihole/releases) and [`CHANGELOG.md`](CHANGELOG.md) for version history.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,10 @@
           "type": "yaml",
           "path": "galaxy.yml",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "README.md"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- register README.md as a release-please generic extra file
- annotate the published-version example so each release PR updates it alongside galaxy.yml and CHANGELOG.md
- retain the durable VERSION install command while showing the current concrete release in prose

## Validation

- `jq empty release-please-config.json`
- `git diff --check`

This follows release-please's documented generic updater and x-release-please-version annotation mechanism.