### PR TITLE
docs: improve future release-note and changelog quality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for helping improve `steveyminecraft.pihole`.
+
+## Branching and promotion
+
+This repository uses topic branches promoted through `dev` and then `master`:
+
+1. Create a topic branch from `dev`.
+2. Open a PR into `dev`.
+3. Promote `dev` to `master` via PR.
+4. Let release automation produce and merge the Release PR on `master`.
+
+See `docs/git-branch-workflow.md` for the full flow and guardrails.
+
+## Conventional commits for useful release notes
+
+This repo uses release-please to generate `CHANGELOG.md` and GitHub release notes.
+Commit subjects directly influence changelog quality.
+
+- `feat:` for user-visible features or capability additions.
+- `fix:` for user-visible bug fixes and regressions.
+- `perf:` for user-visible performance improvements.
+- `refactor:` for internal code structure changes that still matter to operators.
+- `docs:`, `ci:`, `chore:`, `test:`, and `build:` for non-user-facing work.
+
+Good examples:
+
+- `fix: restore keepalived DNS health probe during failover`
+- `feat: add pihole-no-unbound molecule scenario`
+- `perf: reduce update playbook DNS verification retries`
+
+Avoid vague or process-only messages such as:
+
+- `fix: release`
+- `fix: updates`
+- `chore: cleanup`
+
+## Pull request quality checklist
+
+Before opening or merging:
+
+- Ensure PR title and commit subjects describe user-visible impact.
+- Keep formatting-only changes in their own PR where practical.
+- Update `README.md` when behavior, workflows, or setup guidance changes.
+- Confirm CI, linting, and (when relevant) Molecule checks pass.

--- a/README.md
+++ b/README.md
@@ -425,6 +425,16 @@ correctly and generate useful release notes. Prefer a specific user-facing
 summary such as `fix: reject floating latest image defaults` over a generic
 message such as `fix: updates`.
 
+Recommended commit style for high-signal release notes:
+
+- Use `feat:` only for user-visible capabilities or behavior additions.
+- Use `fix:` only for user-visible bug fixes or regressions.
+- Use short imperative subjects that name the changed behavior, not the process.
+- Avoid release-only noise commits (`fix: release`, `chore: updates`) unless they
+  are truly user-facing and should appear in release notes.
+- Keep release-maintenance/documentation-only work under `docs:`, `ci:`, or
+  `chore:` so those entries do not crowd end-user change summaries.
+
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | [Release](.github/workflows/release-please.yml) | Push to `master` only | Release PR; tag + GitHub release + Galaxy publish when the Release PR merges |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,49 @@
       "release-type": "simple",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Chores",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration",
+          "hidden": true
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        }
+      ],
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
## Summary
- Configure `release-please-config.json` changelog sections so release output prioritizes user-facing commit types (`feat`, `fix`, `perf`, `refactor`).
- Hide non-user-facing conventional commit categories (`docs`, `ci`, `chore`, `test`, `build`) from generated changelog sections by default.
- Add contributor guidance in `CONTRIBUTING.md` and expand release guidance in `README.md` for clearer, high-signal commit messages.

## Test plan
- [x] Verify `release-please-config.json` is valid JSON and diffed as intended.
- [x] Confirm docs are lint-clean in editor diagnostics.
- [x] Manual diff review for docs-only behavior.

Made with [Cursor](https://cursor.com)