### PR TITLE
chore: promote dev to master

### DIFF
--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -24,7 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansible-core: [">=2.20.5,<2.21", ">=2.21.0,<2.22"]
+        ansible-core:
+          - ">=2.20.5,<2.21"
+          - ">=2.21.0,<2.22"
 
     steps:
       - name: Check out repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for helping improve `steveyminecraft.pihole`.
+
+## Branching and promotion
+
+This repository uses topic branches promoted through `dev` and then `master`:
+
+1. Create a topic branch from `dev`.
+2. Open a PR into `dev`.
+3. Promote `dev` to `master` via PR.
+4. Let release automation produce and merge the Release PR on `master`.
+
+See `docs/git-branch-workflow.md` for the full flow and guardrails.
+
+## Conventional commits for useful release notes
+
+This repo uses release-please to generate `CHANGELOG.md` and GitHub release notes.
+Commit subjects directly influence changelog quality.
+
+- `feat:` for user-visible features or capability additions.
+- `fix:` for user-visible bug fixes and regressions.
+- `perf:` for user-visible performance improvements.
+- `refactor:` for internal code structure changes that still matter to operators.
+- `docs:`, `ci:`, `chore:`, `test:`, and `build:` for non-user-facing work.
+
+Good examples:
+
+- `fix: restore keepalived DNS health probe during failover`
+- `feat: add pihole-no-unbound molecule scenario`
+- `perf: reduce update playbook DNS verification retries`
+
+Avoid vague or process-only messages such as:
+
+- `fix: release`
+- `fix: updates`
+- `chore: cleanup`
+
+## Pull request quality checklist
+
+Before opening or merging:
+
+- Ensure PR title and commit subjects describe user-visible impact.
+- Keep formatting-only changes in their own PR where practical.
+- Update `README.md` when behavior, workflows, or setup guidance changes.
+- Confirm CI, linting, and (when relevant) Molecule checks pass.

--- a/README.md
+++ b/README.md
@@ -425,6 +425,16 @@ correctly and generate useful release notes. Prefer a specific user-facing
 summary such as `fix: reject floating latest image defaults` over a generic
 message such as `fix: updates`.
 
+Recommended commit style for high-signal release notes:
+
+- Use `feat:` only for user-visible capabilities or behavior additions.
+- Use `fix:` only for user-visible bug fixes or regressions.
+- Use short imperative subjects that name the changed behavior, not the process.
+- Avoid release-only noise commits (`fix: release`, `chore: updates`) unless they
+  are truly user-facing and should appear in release notes.
+- Keep release-maintenance/documentation-only work under `docs:`, `ci:`, or
+  `chore:` so those entries do not crowd end-user change summaries.
+
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | [Release](.github/workflows/release-please.yml) | Push to `master` only | Release PR; tag + GitHub release + Galaxy publish when the Release PR merges |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ For the upstream Pi-hole container image, see: https://github.com/pi-hole/docker
 
 - **ansible-core 2.20 or 2.21**. The normal developer environment uses 2.21
   (see [`requirements.txt`](requirements.txt)); CI also tests the 2.20 runtime floor.
-- **Python 3.13 or 3.14** for the controller (CI tests both; Ubuntu 26.04 ships 3.14—see [`.python-version`](.python-version)).
+- **Python 3.13 or 3.14** for the controller
+  (CI tests both; Ubuntu 26.04 ships 3.14—see
+  [`.python-version`](.python-version)).
 
 ```bash
 ./scripts/setup-env.sh
@@ -23,7 +25,8 @@ source env/bin/activate
 ansible --version   # ansible-core 2.21.x from env/bin/ansible
 ```
 
-Manual venv (if you prefer): `python3.13 -m venv env` or `python3.14 -m venv env`, then `pip install -r requirements.txt`.
+Manual venv (if you prefer): `python3.13 -m venv env` or
+`python3.14 -m venv env`, then `pip install -r requirements.txt`.
 
 This repository is an **Ansible collection** published as
 **`steveyminecraft.pihole`** on
@@ -412,13 +415,18 @@ targets fail before Trivy jobs are created.
 
 Collection metadata is in [`galaxy.yml`](galaxy.yml). The collection is published as **`steveyminecraft.pihole`** on [galaxy.ansible.com](https://galaxy.ansible.com/ui/collections/).
 
-Releases and **git tags** are only created from **`master`** (not `dev` or topic branches). There is no manual release workflow or tag-push publish path.
+Releases and **git tags** are only created from **`master`**
+(not `dev` or topic branches). There is no manual release workflow
+or tag-push publish path.
 
 Uses **[release-please](https://github.com/googleapis/release-please)** (same approach as [ansible-pihole-cluster](https://github.com/danylomikula/ansible-pihole-cluster)):
 
 1. Land work on **`dev`**, then open a PR **`dev` → `master`** and merge (promotion to the release branch).
-2. That push to **`master`** makes release-please open or update a **Release PR** targeting `master` (changelog + `galaxy.yml` version bump).
-3. Merge the **Release PR** into **`master`** to create the **git tag** (`v*.*.*`), **GitHub release**, and **Galaxy publish**.
+2. That push to **`master`** makes release-please open or update a
+   **Release PR** targeting `master` (changelog + `galaxy.yml`
+   version bump).
+3. Merge the **Release PR** into **`master`** to create the **git tag**
+   (`v*.*.*`), **GitHub release**, and **Galaxy publish**.
 
 Use descriptive conventional commits on PRs so release-please can choose semver
 correctly and generate useful release notes. Prefer a specific user-facing

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,49 @@
       "release-type": "simple",
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "section": "Chores",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "section": "Continuous Integration",
+          "hidden": true
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": true
+        }
+      ],
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
## Summary
- Promote merged `dev` changes into `master` per repository release workflow.
- Includes formatting-only readability cleanup and release-note/changelog quality guidance updates.

## Test plan
- [x] Confirm source PRs merged into `dev` (#116, #117).
- [x] Confirm `dev` is ahead of `master` on remote.

Made with [Cursor](https://cursor.com)