### PR TITLE
chore: add PR and commit message quality templates

### DIFF
--- a/.github/commit-message-template.txt
+++ b/.github/commit-message-template.txt
@@ -1,0 +1,20 @@
+<type>(<optional-scope>): <imperative summary>
+
+# Examples:
+# feat(ha): add vip failover smoke check
+# fix(unbound): avoid host publish when container-only resolver is used
+# perf(update): reduce dns verification retries after successful probe
+# docs(readme): document release promotion flow
+#
+# Types:
+# feat, fix, perf, refactor, docs, ci, chore, test, build
+#
+# Guidance:
+# - Write the summary for operators/users, not the implementation process.
+# - Avoid vague subjects such as "updates", "cleanup", or "release".
+# - Keep title <= 72 chars where practical.
+#
+# Optional body (recommended for behavior changes):
+# - Why this change is needed
+# - User-visible impact
+# - Validation performed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+- Describe the user-visible behavior change in 1-3 bullets.
+- If this is internal-only work, say so explicitly.
+
+## Release notes
+
+- Proposed release note sentence:
+  - `<one sentence describing operator/user impact>`
+- Changelog type (pick one):
+  - [ ] `feat`
+  - [ ] `fix`
+  - [ ] `perf`
+  - [ ] `refactor`
+  - [ ] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)
+
+## Validation
+
+- [ ] `ansible-lint` / `yamllint` pass locally or in CI
+- [ ] syntax checks pass for changed playbooks/roles
+- [ ] Molecule or remote functional checks run when behavior changes
+- [ ] README/operational docs updated when needed
+
+## Scope and risk
+
+- Risk level:
+  - [ ] low
+  - [ ] medium
+  - [ ] high
+- Rollback plan:
+  - `<how to revert/mitigate if needed>`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,32 @@ permissions:
   contents: read
 
 jobs:
+  pr-title-check:
+    name: PR title follows conventional commits
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate PR title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|perf|refactor|docs|ci|chore|test|build)(\([a-z0-9._-]+\))?!?: .+'
+          echo "Checking PR title: ${PR_TITLE}"
+          if ! printf '%s' "${PR_TITLE}" | grep -Eq "${pattern}"; then
+            echo "PR title must follow conventional commit style."
+            echo "Expected: type(scope): summary"
+            echo "Examples: fix(ha): restore keepalived DNS probe"
+            echo "          feat: add no-unbound verification scenario"
+            exit 1
+          fi
+      - name: Skip title validation for non-PR events
+        if: github.event_name != 'pull_request'
+        run: echo "PR title validation only runs on pull_request events."
+
   lint:
     name: Ansible & YAML lint (${{ matrix.runner }} / Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.runner }}
+    needs: pr-title-check
     strategy:
       fail-fast: false
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,21 @@ Before opening or merging:
 - Keep formatting-only changes in their own PR where practical.
 - Update `README.md` when behavior, workflows, or setup guidance changes.
 - Confirm CI, linting, and (when relevant) Molecule checks pass.
+
+## Templates and guardrails
+
+- PRs use `.github/pull_request_template.md` to capture release-note details,
+  validation, and risk/rollback notes.
+- CI validates PR titles against conventional commit format
+  (`type(scope): summary`) on pull requests.
+- Optional local commit template:
+
+  ```bash
+  git config commit.template .github/commit-message-template.txt
+  ```
+
+  You can set this globally if preferred:
+
+  ```bash
+  git config --global commit.template /absolute/path/to/.github/commit-message-template.txt
+  ```

--- a/README.md
+++ b/README.md
@@ -443,6 +443,14 @@ Recommended commit style for high-signal release notes:
 - Keep release-maintenance/documentation-only work under `docs:`, `ci:`, or
   `chore:` so those entries do not crowd end-user change summaries.
 
+PR quality scaffolding is now included in-repo:
+
+- `.github/pull_request_template.md` prompts release-note summary, validation,
+  and risk/rollback details.
+- `.github/commit-message-template.txt` provides optional local commit-message
+  guidance (`git config commit.template .github/commit-message-template.txt`).
+- CI checks PR titles on pull requests for conventional commit format.
+
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | [Release](.github/workflows/release-please.yml) | Push to `master` only | Release PR; tag + GitHub release + Galaxy publish when the Release PR merges |


### PR DESCRIPTION
## Summary
- Add `.github/pull_request_template.md` to require release-note summary, validation notes, and risk/rollback details.
- Add `.github/commit-message-template.txt` with conventional-commit scaffolding for consistent, high-signal commit messages.
- Add a CI PR-title check in `.github/workflows/ci.yml` to enforce conventional-title format on pull requests.
- Document template usage in `CONTRIBUTING.md` and `README.md`.

## Test plan
- [x] Verify changed files have no IDE lint diagnostics.
- [x] Review diff for docs/workflow-only scope.
- [x] Validate JSON config parsing with `python3 -m json.tool`.

Made with [Cursor](https://cursor.com)