### PR TITLE
chore: switch repository workflow to master-only

### DIFF
--- a/.cursor/skills/git-branch-workflow/SKILL.md
+++ b/.cursor/skills/git-branch-workflow/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: git-branch-workflow
 description: >-
-  Defines steveyminecraft/ansible-pihole Git branch promotion:
-  topic branch → dev → master. Use when creating branches, merging, opening
-  PRs, syncing dev with master, or any git workflow in this repository.
+  Defines steveyminecraft/ansible-pihole Git branch flow:
+  topic branch → master. Use when creating branches, merging, opening
+  PRs, or any git workflow in this repository.
 ---
 
 # ansible-pihole Git branch workflow
@@ -11,57 +11,47 @@ description: >-
 ## Branch flow
 
 ```
-<topic-branch>  →  dev  →  master
+<topic-branch>  →  master
 ```
 
 - **Topic branches** (`feature/*`, `bugfix/*`, `fix/*`, `chore/*`, etc.): all implementation work happens here.
-- **`dev`**: integration branch; topic branches merge here first.
-- **`master`**: release/production line; only promoted from `dev` (except emergency hotfixes—then sync `dev` back).
+- **`master`**: integration + release/production branch.
 
-Do **not** land feature work directly on `master`. Do **not** long-lived development on `dev` without a topic branch when the change is non-trivial.
+Do **not** do long-lived development directly on `master` when the change is non-trivial.
 
 ## Agent rules
 
-1. **Start new work only after refreshing local `master` and `dev` from the current remote `master`**:
+1. **Start new work only after refreshing local `master` from remote `master`**:
    ```bash
    git fetch origin
    git checkout master
    git pull --ff-only origin master
-   git checkout dev
-   git pull --ff-only origin dev
-   git merge --ff-only master
    git checkout -b feature/short-description   # or bugfix/, fix/, chore/
    ```
-   If `dev` cannot fast-forward to `master`, stop and ask the user how to reconcile before creating the topic branch.
 
 2. **Merge direction** (one way):
-   - Topic branch → `dev` (PR preferred)
-   - `dev` → `master` (PR preferred)
-   - Never merge `master` into a topic branch for “latest code” unless resolving a specific conflict—prefer rebasing the topic branch onto `dev` after syncing `dev` with `master`.
+   - Topic branch → `master` (PR preferred)
+   - Never merge `master` into a topic branch for “latest code” unless resolving a specific conflict—prefer rebasing the topic branch onto `master`.
 
-3. **Before starting work**, always verify local `master` and `dev` are current:
+3. **Before starting work**, always verify local `master` is current:
    ```bash
    git fetch origin
    git checkout master
    git pull --ff-only origin master
-   git checkout dev
-   git pull --ff-only origin dev
-   git merge --ff-only master
    git status -sb
    ```
    If fast-forward is not possible, stop and ask the user how to reconcile (do not force-push).
 
-4. **After `master` moves** (release merge, hotfix), bring `dev` current the same way (fast-forward when `dev` has no unique commits).
+4. **After `master` moves** (release merge, hotfix), rebase active topic branches onto `master` as needed.
 
 5. **PR targets**:
-   - Topic branch → **`dev`**
-   - `dev` → **`master`**
+   - Topic branch → **`master`**
 
 6. **After a topic branch is merged**, delete it locally and remotely to keep repo hygiene:
    ```bash
    git fetch origin --prune
-   git checkout dev
-   git pull --ff-only origin dev
+   git checkout master
+   git pull --ff-only origin master
    git branch -d feature/short-description
    git push origin --delete feature/short-description
    git fetch origin --prune
@@ -74,19 +64,15 @@ Do **not** land feature work directly on `master`. Do **not** long-lived develop
 
 ## CI context
 
-GitHub Actions (`.github/workflows/ci.yml`) run on push/PR to `dev`, `master`, and pushes to `feature/**`. Topic branches get CI before merge to `dev`.
+GitHub Actions (`.github/workflows/ci.yml`) run on push/PR to `master`, and pushes to `feature/**`. Topic branches get CI before merge to `master`.
 
 ## Quick checklist
 
 ```
 - [ ] local master is fast-forwarded to origin/master
-- [ ] local dev is fast-forwarded to origin/dev
-- [ ] dev is synced with current master before branching
-- [ ] branch created from dev
-- [ ] changes merged to dev via PR
+- [ ] branch created from master
+- [ ] changes merged to master via PR
 - [ ] merged topic branch deleted locally
 - [ ] merged topic branch deleted from origin
-- [ ] dev promoted to master via PR
-- [ ] after master release: dev fast-forwarded to master
 - [ ] README(s) updated (see readme-maintenance skill)
 ```

--- a/.cursor/skills/readme-maintenance/SKILL.md
+++ b/.cursor/skills/readme-maintenance/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: readme-maintenance
+description: >-
+  Requires keeping README.md files in steveyminecraft/ansible-pihole accurate
+  whenever code, config, CI, Molecule, setup, or behavior changes. Use on every
+  implementation task in this repository, before finishing work or opening a PR.
+---
+
+# README maintenance (ansible-pihole)
+
+**READMEs must stay up to date at all times.** Treat README updates as part of the same change—not a follow-up.
+
+Also apply the **readme-change-log** user skill when editing this repo. This file adds repo-specific scope.
+
+## Files to maintain
+
+| File | Update when |
+|------|-------------|
+| `README.md` (repo root) | Playbooks, roles, install, Molecule scenarios, CI, inventory, scripts, Galaxy/meta, supported OS versions, branch/workflow notes |
+| `roles/unbound/README.md` | Unbound role behavior, variables, images, or usage |
+
+If you add a new role with its own `README.md`, keep that file current too.
+
+## When to edit (non-exhaustive)
+
+Update README(s) in the **same commit/PR** as the functional change when you touch:
+
+- `.github/workflows/` or Actions under `.github/actions/`
+- `molecule/` (scenarios, boxes, providers, test sequence)
+- `playbooks/`, `inventory/`, `roles/`
+- `scripts/` users run (`install-ansible-collections.sh`, `molecule-vagrant`, etc.)
+- `meta/main.yml` (Galaxy platforms, versions)
+- Dependencies (`roles/requirements.yml`, `collections/requirements.yml`)
+
+Skip README edits only if the user explicitly says not to, or the change is purely internal with zero user-visible effect (rare—when in doubt, update).
+
+## Where to put updates
+
+Match existing root `README.md` sections:
+
+- **Setup / requirements** — Python 3.13 or 3.14, ansible-core 2.20.x, venv/`requirements.txt`, Vagrant, Galaxy collections
+- **Molecule integration tests** — scenarios, boxes (e.g. Ubuntu version), provider/inventory env vars
+- **CI** — what workflows run and on which branches
+- **Usage / playbooks** — commands, tags, inventory paths
+
+Prefer **editing stale text in place** over duplicating. Remove wrong version numbers (e.g. old Ubuntu box names) when replacing with new ones.
+
+## Completion check (every task)
+
+Before marking work done or suggesting a PR:
+
+```
+- [ ] Root README.md reflects the change (or consciously N/A)
+- [ ] Role README(s) updated if role behavior/docs changed
+- [ ] No contradictions (old platform versions, removed scripts, wrong branch names)
+```
+
+Include README changes in the topic-branch PR to `master`, not a separate doc-only PR unless the user requests that.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ name: CI - Ansible-Pihole Checks
 "on":
   push:
     branches:
-      - dev
       - master
       - "feature/**"
   pull_request:
     branches:
-      - dev
       - master
   workflow_dispatch:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,6 @@
 ---
 # Releases and tags are only produced from the master branch.
-# Typical flow: merge topic → dev → PR dev → master (opens/updates a Release PR) →
+# Typical flow: merge topic PRs to master (opens/updates a Release PR) →
 # merge Release PR → tag v*.*.*, GitHub release, Galaxy publish.
 # No workflow_dispatch or tag-push triggers (see removed release.yml).
 name: Release

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,12 +4,10 @@ name: Security scanning
 "on":
   push:
     branches:
-      - dev
       - master
       - "feature/**"
   pull_request:
     branches:
-      - dev
       - master
   schedule:
     - cron: "21 4 * * 1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,11 @@ Thanks for helping improve `steveyminecraft.pihole`.
 
 ## Branching and promotion
 
-This repository uses topic branches promoted through `dev` and then `master`:
+This repository uses topic branches merged directly into `master`:
 
-1. Create a topic branch from `dev`.
-2. Open a PR into `dev`.
-3. Promote `dev` to `master` via PR.
-4. Let release automation produce and merge the Release PR on `master`.
+1. Create a topic branch from the latest `master`.
+2. Open a PR into `master`.
+3. Let release automation produce and merge the Release PR on `master`.
 
 See `docs/git-branch-workflow.md` for the full flow and guardrails.
 

--- a/README.md
+++ b/README.md
@@ -415,13 +415,12 @@ targets fail before Trivy jobs are created.
 
 Collection metadata is in [`galaxy.yml`](galaxy.yml). The collection is published as **`steveyminecraft.pihole`** on [galaxy.ansible.com](https://galaxy.ansible.com/ui/collections/).
 
-Releases and **git tags** are only created from **`master`**
-(not `dev` or topic branches). There is no manual release workflow
-or tag-push publish path.
+Releases and **git tags** are only created from **`master`**.
+There is no manual release workflow or tag-push publish path.
 
 Uses **[release-please](https://github.com/googleapis/release-please)** (same approach as [ansible-pihole-cluster](https://github.com/danylomikula/ansible-pihole-cluster)):
 
-1. Land work on **`dev`**, then open a PR **`dev` → `master`** and merge (promotion to the release branch).
+1. Merge topic PRs into **`master`**.
 2. That push to **`master`** makes release-please open or update a
    **Release PR** targeting `master` (changelog + `galaxy.yml`
    version bump).

--- a/docs/git-branch-workflow.md
+++ b/docs/git-branch-workflow.md
@@ -1,18 +1,19 @@
 # Git Branch Workflow
 
-Use this workflow before starting implementation work so topic branches are based on the current release line and do not regress fixes already merged to `master`.
+Use this workflow before starting implementation work so topic branches are
+based on the current release line and do not regress fixes already merged to
+`master`.
 
 ## Branch Flow
 
 ```text
-topic branch -> dev -> master
+topic branch -> master
 ```
 
-- Create implementation branches from `dev` only after syncing local `master` and `dev`.
-- Merge topic branches into `dev` first.
-- Promote `dev` to `master` by PR when ready to release.
+- Create implementation branches from `master` after syncing local `master`.
+- Merge topic branches directly into `master`.
 - Delete merged topic branches locally and remotely after the merge is complete.
-- Do not do long-lived implementation directly on `dev` or `master`.
+- Do not do long-lived implementation directly on `master`.
 
 ## Before Creating A Topic Branch
 
@@ -24,28 +25,22 @@ git fetch origin
 git checkout master
 git pull --ff-only origin master
 
-git checkout dev
-git pull --ff-only origin dev
-git merge --ff-only master
-
 git checkout -b feature/short-description
 ```
 
-If `dev` cannot fast-forward or merge cleanly from `master`, stop and reconcile `dev` before creating the topic branch. Do not create a new branch from stale local refs.
+Do not create a new branch from stale local refs.
 
 ## Existing Topic Branches
 
-Before continuing work on an existing topic branch, rebase it onto the current `master` or the refreshed `dev`, depending on the PR target:
+Before continuing work on an existing topic branch, rebase it onto the current
+`master`:
 
 ```bash
 git fetch origin
 git checkout master
 git pull --ff-only origin master
-git checkout dev
-git pull --ff-only origin dev
-git merge --ff-only master
 git checkout feature/short-description
-git rebase dev
+git rebase master
 ```
 
 After rebasing a branch that was already pushed, update the remote with `--force-with-lease`.
@@ -56,8 +51,8 @@ Keep the repository tidy by deleting merged topic branches in both places:
 
 ```bash
 git fetch origin --prune
-git checkout dev
-git pull --ff-only origin dev
+git checkout master
+git pull --ff-only origin master
 git branch -d feature/short-description
 git push origin --delete feature/short-description
 ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -61,5 +61,5 @@
     }
   },
   "pull-request-title-pattern": "chore: release ${version}",
-  "pull-request-footer": "Merge this PR into master to create the git tag, GitHub release, and publish steveyminecraft.pihole to Ansible Galaxy. Feature work should land on master via dev first."
+  "pull-request-footer": "Merge this PR into master to create the git tag, GitHub release, and publish steveyminecraft.pihole to Ansible Galaxy."
 }


### PR DESCRIPTION
## Summary
- Remove `dev` from CI and security workflow branch triggers; keep checks on `master` and feature branches.
- Update release and branch-flow documentation to a simpler `topic branch -> master` model.
- Align release-please footer guidance and Cursor skill docs with the new master-only flow.

## Test plan
- [x] Check updated YAML/Markdown/skill files for lint diagnostics.
- [x] Validate `release-please-config.json` parses with `python3 -m json.tool`.
- [x] Grep docs/workflows to confirm stale `dev` workflow references are removed.

Made with [Cursor](https://cursor.com)