### PR TITLE
fix: harden AWS remote cleanup on provisioning failures

### DIFF
--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: AWS remote functional tests
+name: "CI — Pi-hole: AWS EC2 (manual)"
 
 on:
   workflow_dispatch:
@@ -48,7 +48,7 @@ concurrency:
 
 jobs:
   prepare-matrix:
-    name: Prepare AWS test matrix
+    name: Prepare manual EC2 matrix
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -97,7 +97,7 @@ jobs:
           PY
 
   aws-remote-tests:
-    name: AWS integration — Ubuntu ${{ matrix.os_version }} / ${{ matrix.arch }}
+    name: Ubuntu ${{ matrix.os_version }} / ${{ matrix.arch }}
     needs: prepare-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 90

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: AWS RC remote tests
+name: "CI — Pi-hole: AWS EC2 (RC)"
 
 on:
   push:
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   aws-rc-remote-tests:
-    name: AWS integration — Pi-hole on Ubuntu 26.04 (RC)
+    name: Ubuntu 26.04 / amd64 (RC)
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,7 +92,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${rc_tag}" -m "Release candidate for ${base_tag} (release PR ${head_sha::7})" "${head_sha}"
           git push origin "${rc_tag}"
-          echo "Pushed ${rc_tag}; AWS RC remote tests will start automatically."
+          echo "Pushed ${rc_tag}; CI — Pi-hole: AWS EC2 (RC) will start automatically."
 
   publish-galaxy:
     name: Publish collection to Ansible Galaxy

--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ network, or Unbound health check dependency. Hosted CI runs Python unit tests in
 `tests/unit/` so malformed, empty, incomplete, or floating `latest` scan
 targets fail before Trivy jobs are created.
 
-AWS remote functional tests use ephemeral EC2 hosts and lifecycle hooks wired
-into `tests/remote/run.sh`:
+AWS EC2 workflows use ephemeral hosts and lifecycle hooks wired into
+`tests/remote/run.sh`:
 
-- `.github/workflows/rc-aws-remote-tests.yml` — RC tags (`v*-rc*`), Ubuntu 26.04
-- `.github/workflows/aws-remote-tests.yml` — manual dispatch only
+- `.github/workflows/rc-aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (RC)** (`v*-rc*`, Ubuntu 26.04)
+- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (manual)** (`workflow_dispatch`)
 - `.github/workflows/pihole-image-watch.yml` — daily check for new `pihole/pihole` Docker tags (GitHub issue alert)
 
 Infrastructure (VPC subnet, OIDC role, SSH key pair) is provisioned in the

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -4,7 +4,7 @@ This document explains how the GitHub Actions AWS remote test workflows operate,
 
 There are **two related workflows**. They share the same scripts and AWS setup; they differ mainly in **when they run** and **how much they test**.
 
-| | **AWS RC remote tests** | **AWS remote functional tests** |
+| | **CI — Pi-hole: AWS EC2 (RC)** | **CI — Pi-hole: AWS EC2 (manual)** |
 |---|---|---|
 | File | `.github/workflows/rc-aws-remote-tests.yml` | `.github/workflows/aws-remote-tests.yml` |
 | Triggers | RC tags (`v1.0.0-rc.1`) or manual | Manual `workflow_dispatch` only |

--- a/tests/remote/aws/create-ephemeral-env.sh
+++ b/tests/remote/aws/create-ephemeral-env.sh
@@ -25,6 +25,42 @@ for var_name in "${required_vars[@]}"; do
   fi
 done
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+write_state_file() {
+  local instance_ids_json="[]"
+  local state_dir state_tmp
+  if [[ -n "${instance_id:-}" ]]; then
+    instance_ids_json="[\"${instance_id}\"]"
+  fi
+
+  state_dir="$(dirname "${AWS_STATE_FILE}")"
+  state_tmp="$(mktemp "${state_dir}/aws-state.XXXXXX")"
+  cat > "${state_tmp}" <<EOF
+{
+  "region": "${AWS_REGION}",
+  "instance_ids": ${instance_ids_json},
+  "security_group_id": "${security_group_id:-}"
+}
+EOF
+  mv "${state_tmp}" "${AWS_STATE_FILE}"
+}
+
+cleanup_on_failure() {
+  local exit_code="$?"
+  if [[ "${exit_code}" -eq 0 ]]; then
+    return
+  fi
+
+  if [[ -f "${AWS_STATE_FILE}" ]]; then
+    echo "Provisioning failed; attempting best-effort AWS cleanup." >&2
+    if ! "${script_dir}/destroy-ephemeral-env.sh"; then
+      echo "WARNING: best-effort cleanup failed; manual AWS cleanup may be required." >&2
+    fi
+  fi
+}
+trap cleanup_on_failure EXIT
+
 if [[ ! -f "${AWS_INVENTORY_TEMPLATE}" ]]; then
   echo "Inventory template not found: ${AWS_INVENTORY_TEMPLATE}" >&2
   exit 2
@@ -65,6 +101,8 @@ name_suffix="$(date +%s)-${RANDOM}"
 name_prefix="${AWS_TEST_PREFIX:-ansible-pihole-remote}"
 security_group_name="${name_prefix}-sg-${name_suffix}"
 resource_name="${name_prefix}-${AWS_OS_FAMILY}-${AWS_ARCH}-${name_suffix}"
+instance_id=""
+security_group_id=""
 
 if [[ -s "${AWS_STATE_FILE}" ]]; then
   echo "State file already exists (${AWS_STATE_FILE}); refusing to overwrite." >&2
@@ -95,6 +133,9 @@ security_group_id="$(aws ec2 create-security-group \
   --query 'GroupId' \
   --output text)"
 
+mkdir -p "$(dirname "${AWS_STATE_FILE}")" "$(dirname "${AWS_INVENTORY_FILE}")" "$(dirname "${AWS_METADATA_FILE}")"
+write_state_file
+
 aws ec2 authorize-security-group-ingress \
   --region "${AWS_REGION}" \
   --group-id "${security_group_id}" \
@@ -116,6 +157,7 @@ instance_id="$(aws ec2 run-instances \
   --count 1 \
   --query 'Instances[0].InstanceId' \
   --output text)"
+write_state_file
 
 aws ec2 wait instance-running --region "${AWS_REGION}" --instance-ids "${instance_id}"
 aws ec2 wait instance-status-ok --region "${AWS_REGION}" --instance-ids "${instance_id}"
@@ -142,15 +184,7 @@ if [[ -z "${private_ip}" || "${private_ip}" == "None" ]]; then
   exit 2
 fi
 
-mkdir -p "$(dirname "${AWS_STATE_FILE}")" "$(dirname "${AWS_INVENTORY_FILE}")" "$(dirname "${AWS_METADATA_FILE}")"
-
-cat > "${AWS_STATE_FILE}" <<EOF
-{
-  "region": "${AWS_REGION}",
-  "instance_ids": ["${instance_id}"],
-  "security_group_id": "${security_group_id}"
-}
-EOF
+write_state_file
 
 cat > "${AWS_METADATA_FILE}" <<EOF
 {

--- a/tests/unit/test_aws_create_cleanup_on_failure.py
+++ b/tests/unit/test_aws_create_cleanup_on_failure.py
@@ -1,0 +1,138 @@
+"""Tests AWS create script failure cleanup behavior."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CREATE_SCRIPT = REPO_ROOT / "tests" / "remote" / "aws" / "create-ephemeral-env.sh"
+
+
+class AwsCreateCleanupOnFailureTests(unittest.TestCase):
+    def run_create_with_failure(self, fail_on: str) -> tuple[subprocess.CompletedProcess[str], str, Path]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_dir = Path(tmpdir)
+            fake_bin = temp_dir / "bin"
+            fake_bin.mkdir()
+            aws_log = temp_dir / "aws.log"
+            aws_script = fake_bin / "aws"
+            aws_script.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$AWS_LOG"
+if [[ "$1" == "ssm" && "$2" == "get-parameter" ]]; then
+  echo "ami-1234567890"
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "describe-subnets" ]]; then
+  echo "vpc-1234567890"
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "create-security-group" ]]; then
+  echo "sg-1234567890"
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "authorize-security-group-ingress" ]]; then
+  if [[ "${FAIL_ON:-}" == "authorize-ingress" ]]; then
+    exit 99
+  fi
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "run-instances" ]]; then
+  echo "i-1234567890"
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "wait" && "$3" == "instance-running" ]]; then
+  if [[ "${FAIL_ON:-}" == "instance-running-wait" ]]; then
+    exit 98
+  fi
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "wait" && "$3" == "instance-status-ok" ]]; then
+  exit 99
+fi
+if [[ "$1" == "ec2" && "$2" == "delete-security-group" ]]; then
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "describe-instances" ]]; then
+  echo "0"
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "terminate-instances" ]]; then
+  exit 0
+fi
+if [[ "$1" == "ec2" && "$2" == "wait" ]]; then
+  exit 0
+fi
+exit 0
+""",
+                encoding="utf-8",
+            )
+            aws_script.chmod(aws_script.stat().st_mode | stat.S_IXUSR)
+
+            inventory_template = temp_dir / "inventory-template.yml"
+            inventory_template.write_text("all:\n  hosts: {}\n", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{fake_bin}:{env.get('PATH', '')}",
+                    "AWS_LOG": str(aws_log),
+                    "FAIL_ON": fail_on,
+                    "AWS_REGION": "eu-west-1",
+                    "AWS_SUBNET_ID": "subnet-123",
+                    "AWS_KEY_NAME": "example-key",
+                    "AWS_INSTANCE_TYPE": "t3.micro",
+                    "AWS_OS_FAMILY": "ubuntu",
+                    "AWS_OS_VERSION": "26.04",
+                    "AWS_ARCH": "amd64",
+                    "AWS_TEST_SCENARIO": "pihole-unbound",
+                    "AWS_SSH_PRIVATE_KEY_PATH": str(temp_dir / "id_rsa"),
+                    "AWS_INVENTORY_FILE": str(temp_dir / "inventory.yml"),
+                    "AWS_STATE_FILE": str(temp_dir / "state.json"),
+                    "AWS_METADATA_FILE": str(temp_dir / "metadata.json"),
+                    "AWS_CLEANUP_STATUS_FILE": str(temp_dir / "cleanup.json"),
+                    "AWS_INVENTORY_TEMPLATE": str(inventory_template),
+                    "PIHOLE_API_PASSWORD": "not-a-secret",
+                    "GITHUB_USER_FOR_SSH_KEY": "ubuntu",
+                }
+            )
+
+            result = subprocess.run(
+                [str(CREATE_SCRIPT)],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            log_lines = aws_log.read_text(encoding="utf-8")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue((temp_dir / "cleanup.json").exists())
+            self.assertFalse((temp_dir / "state.json").exists())
+            return result, log_lines, temp_dir
+
+    def test_authorize_ingress_failure_triggers_cleanup(self) -> None:
+        _, log_lines, _ = self.run_create_with_failure("authorize-ingress")
+        self.assertIn("create-security-group", log_lines)
+        self.assertIn("authorize-security-group-ingress", log_lines)
+        self.assertIn("delete-security-group", log_lines)
+        self.assertIn("sg-1234567890", log_lines)
+
+    def test_instance_wait_failure_terminates_instance_and_cleans_up(self) -> None:
+        _, log_lines, _ = self.run_create_with_failure("instance-running-wait")
+        self.assertIn("run-instances", log_lines)
+        self.assertIn("terminate-instances", log_lines)
+        self.assertIn("i-1234567890", log_lines)
+        self.assertIn("delete-security-group", log_lines)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- persist AWS cleanup state as resources are created so partial provisioning failures still have teardown context
- add a failure trap in remote environment creation to run best-effort destroy when provisioning exits non-zero
- add unit coverage for both pre-instance and post-instance provisioning failure paths

## Test plan
- [x] `python3 -m unittest tests/unit/test_aws_create_cleanup_on_failure.py`
- [ ] Run `AWS remote functional tests` workflow manually for `pihole-unbound`
- [ ] Confirm workflow summary shows `Cleanup verified: true`

Made with [Cursor](https://cursor.com)