### PR TITLE
fix: bump pinned Pi-hole image to 2026.06.0

### DIFF
--- a/playbooks/ci-bootstrap.yaml
+++ b/playbooks/ci-bootstrap.yaml
@@ -19,7 +19,7 @@
 
     password_lock: false
     # Point Pi-hole image at something valid, but we're in --check anyway
-    pihole_image: "pihole/pihole:2026.05.0"
+    pihole_image: "pihole/pihole:2026.06.0"
     pihole_compose_dir: "/opt/pihole"
 
   roles:

--- a/playbooks/ci-validate-pihole-modes.yaml
+++ b/playbooks/ci-validate-pihole-modes.yaml
@@ -5,7 +5,7 @@
   gather_facts: false
   vars:
     pihole_container_name: pihole
-    pihole_image: "pihole/pihole:2026.05.0"
+    pihole_image: "pihole/pihole:2026.06.0"
     pihole_dir_loc: /opt/pihole
     pihole_network_name: dns_net
     pihole_use_host_network: false

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -8,7 +8,7 @@
 # tasks/main.yml aligns pihole_dir_loc so volume paths match the playbook.
 pihole_dir_loc: '/opt/pihole'
 pihole_compose_dir: "{{ pihole_dir_loc }}"
-pihole_image: "pihole/pihole:2026.05.0"
+pihole_image: "pihole/pihole:2026.06.0"
 pihole_firewall_deploy: "{{ lookup('ansible.builtin.vars', 'firewall_deploy', default=false) | bool }}"
 
 # Deploy and integrate Unbound by default for backwards compatibility. When


### PR DESCRIPTION
## Summary
- Bump the pinned Pi-hole image from `2026.05.0` to `2026.06.0` in role defaults.
- Keep CI mirrors aligned by updating the same pin in `playbooks/ci-bootstrap.yaml` and `playbooks/ci-validate-pihole-modes.yaml`.
- Track and resolve upstream update issue #126 and Jira `AWSC-42`.

## Test plan
- [x] `python3 -m unittest discover -s tests/unit -p 'test_*.py'`
- [x] `python3 scripts/validate-secure-defaults.py`
- [x] `python3 scripts/default-container-images.py`
- [x] Run full Molecule scenarios (self-hosted/local as needed)
- [ ] Run Trivy/security workflow in GitHub Actions

Closes #126
Refs: AWSC-42

Made with [Cursor](https://cursor.com)