### PR TITLE
fix(ci): pass --no-cache to ansible-galaxy installs

### DIFF
--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -57,7 +57,9 @@ jobs:
           trap 'rm -rf "${consumer_root}"' EXIT
           cd "${consumer_root}"
 
-          ansible-galaxy collection install "${artifact}" -p collections --force
+          # --no-cache avoids the ansible-galaxy response-cache corruption
+          # bug (KeyError: 'results') seen under concurrent CI runs.
+          ansible-galaxy collection install "${artifact}" -p collections --force --no-cache
           test -d collections/ansible_collections/ansible/posix
 
           installed="${consumer_root}/collections/ansible_collections/steveyminecraft/pihole"

--- a/scripts/install-ansible-collections.sh
+++ b/scripts/install-ansible-collections.sh
@@ -18,8 +18,10 @@ if [[ ! -f "$artifact" ]]; then
   exit 1
 fi
 rm -rf "$COL/ansible_collections/steveyminecraft/pihole"
-ansible-galaxy collection install "${artifact}" -p "$COL" --force
+# --no-cache avoids the ansible-galaxy response-cache corruption bug
+# (KeyError: 'results') that surfaces under concurrent CI runs.
+ansible-galaxy collection install "${artifact}" -p "$COL" --force --no-cache
 
 if [[ -f "$ROOT/collections/requirements.yml" ]]; then
-  ansible-galaxy collection install -r "$ROOT/collections/requirements.yml" -p "$COL"
+  ansible-galaxy collection install -r "$ROOT/collections/requirements.yml" -p "$COL" --no-cache
 fi


### PR DESCRIPTION
## Summary
- CI's lint and "Build and validate steveyminecraft.pihole" jobs intermittently fail with `KeyError: 'results'` / `Missing expected 'results' in ansible-galaxy cache`. This is the documented ansible-galaxy response-cache corruption bug that surfaces under concurrent CI runs — it is unrelated to any source change (e.g. it currently red-flags dependabot #133, where the identical `>=2.21.0,<2.22` matrix leg passes while `>=2.20.5,<2.21` fails).
- Apply the workaround Ansible itself recommends in the error message (`--no-cache`) to the Galaxy-touching collection installs so dependency resolution no longer reads the corrupt cache.

## Changes
- `scripts/install-ansible-collections.sh`: add `--no-cache` to the local artifact install and the `collections/requirements.yml` install (fixes the **lint** jobs).
- `.github/workflows/galaxy-publish.yml`: add `--no-cache` to the clean consumer install (fixes the **Build and validate** jobs).

## Test plan
- [ ] CI lint matrix (ubuntu-24.04 / ubuntu-24.04-arm, Python 3.13/3.14) goes green.
- [ ] `Build and validate steveyminecraft.pihole` for both `>=2.20.5,<2.21` and `>=2.21.0,<2.22` goes green.
- [ ] After merge, re-run / rebase dependabot #133 and confirm it passes.

Made with [Cursor](https://cursor.com)