### PR TITLE
chore(deps): bump ansible-core floor to >=2.21.1,<2.22

### DIFF
--- a/.github/actions/import-galaxy-role/action.yml
+++ b/.github/actions/import-galaxy-role/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Install Ansible
       shell: bash
-      run: python -m pip install 'ansible-core>=2.21.0,<2.22'
+      run: python -m pip install 'ansible-core>=2.21.1,<2.22'
 
     - name: Import role into Ansible Galaxy
       shell: bash

--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.0,<2.22'
+          python -m pip install --upgrade 'ansible-core>=2.21.1,<2.22'
 
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.0,<2.22' ansible-lint yamllint galaxy-importer
+          python -m pip install --upgrade 'ansible-core>=2.21.1,<2.22' ansible-lint yamllint galaxy-importer
 
       - name: Build and validate collection for Ansible Galaxy
         run: |
@@ -95,7 +95,7 @@ jobs:
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
         python-version: ["3.13", "3.14"]
-        ansible-core: [">=2.20.5,<2.21", ">=2.21.0,<2.22"]
+        ansible-core: [">=2.20.5,<2.21", ">=2.21.1,<2.22"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         ansible-core:
           - ">=2.20.5,<2.21"
-          - ">=2.21.0,<2.22"
+          - ">=2.21.1,<2.22"
 
     steps:
       - name: Check out repository

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.0,<2.22'
+          python -m pip install --upgrade 'ansible-core>=2.21.1,<2.22'
 
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -147,7 +147,7 @@ jobs:
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
         run: |
-          python -m pip install --upgrade pip 'ansible-core>=2.21.0,<2.22'
+          python -m pip install --upgrade pip 'ansible-core>=2.21.1,<2.22'
           ansible-galaxy collection build
           if [ -z "${GALAXY_API_KEY:-}" ]; then
             echo "GALAXY_API_KEY is not set; skipping Galaxy publish."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Normal developer toolchain (Python 3.13 or 3.14).
 # CI also tests the supported ansible-core 2.20 runtime floor.
-ansible-core>=2.21.0,<2.22
+ansible-core>=2.21.1,<2.22
 ansible-lint>=26.4.0
 yamllint>=1.38.0
 molecule>=26.4.0

--- a/scripts/check-ansible-version-policy.py
+++ b/scripts/check-ansible-version-policy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 MINIMUM = ">=2.20.5,<2.21"
-LATEST = ">=2.21.0,<2.22"
+LATEST = ">=2.21.1,<2.22"
 
 
 def require(path: str, text: str) -> None:


### PR DESCRIPTION
## Summary

- Raises the supported **ansible-core** floor from `>=2.21.0,<2.22` to `>=2.21.1,<2.22` in `requirements.txt`, CI matrices, Galaxy publish workflows, and the ansible version policy checker.
- Aligns all workflow install steps and the import-galaxy composite action with the updated constraint.

## Commits

- `chore(deps): Update ansible-core requirement`
- `fix(ci): align ansible-core support floor to 2.21.1`

## Test plan

- [ ] CI matrix passes on Ubuntu 24.04 / 24.04-arm with Python 3.13 and 3.14
- [ ] Galaxy publish workflow succeeds for both ansible-core matrix legs
- [ ] `./scripts/check-ansible-version-policy.py` passes locally
- [ ] AWS remote test workflows install ansible-core 2.21.1+ successfully


Made with [Cursor](https://cursor.com)