### PR TITLE
fix: harden pihole phase-one deployment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ Pi-hole-related variables (e.g. `pihole_environment_variables`, `pihole_ha_mode`
 
 Role-local variable naming now consistently uses the `pihole_` prefix to satisfy ansible-lint role scoping rules (for example `pihole_dir_loc`, `pihole_webport_http`, `pihole_docker_manage_iptables`). Existing inventories that still define legacy unprefixed names continue to work via compatibility lookups, but new configs should use the prefixed names.
 
+Pi-hole image pulls map common host architectures to Docker platform strings via
+`pihole_docker_platform_arch_map` (`x86_64`/`amd64` -> `linux/amd64`,
+`aarch64`/`arm64` -> `linux/arm64`, `armv7l` -> `linux/arm/v7`,
+`armv6l` -> `linux/arm/v6`). Unknown architectures omit the platform argument
+and let Docker choose the best matching image.
+
 Security defaults:
 
 - `FTLCONF_webserver_api_password` must be provided from inventory/vault and should be at least 16 characters.

--- a/playbooks/ci-validate-pihole-modes.yaml
+++ b/playbooks/ci-validate-pihole-modes.yaml
@@ -13,10 +13,42 @@
     pihole_docker_dns: []
     pihole_webport_http: "80"
     pihole_webport_https: "443"
+    pihole_docker_platform_arch_map:
+      x86_64: linux/amd64
+      amd64: linux/amd64
+      aarch64: linux/arm64
+      arm64: linux/arm64
+      armv7l: linux/arm/v7
+      armv6l: linux/arm/v6
+    pihole_vars_environment_variables:
+      TZ: UTC
+      FTLCONF_dns_listeningMode: ALL
     pihole_environment_variables:
+      TZ: Europe/London
       DHCP_ACTIVE: false
       FTLCONF_dns_upstreams: "1.1.1.1;1.0.0.1"
   tasks:
+    - name: Merge Pi-hole role and inventory environment variables
+      ansible.builtin.set_fact:
+        pihole_environment_variables: >-
+          {{
+            pihole_vars_environment_variables | default({})
+            | combine(pihole_environment_variables | default({}), recursive=True)
+          }}
+
+    - name: Assert Pi-hole environment variable merge precedence
+      ansible.builtin.assert:
+        that:
+          - pihole_environment_variables.TZ == 'Europe/London'
+          - pihole_environment_variables.FTLCONF_dns_listeningMode == 'ALL'
+
+    - name: Assert Pi-hole Docker platform architecture map
+      ansible.builtin.assert:
+        that:
+          - pihole_docker_platform_arch_map.x86_64 == 'linux/amd64'
+          - pihole_docker_platform_arch_map.aarch64 == 'linux/arm64'
+          - pihole_docker_platform_arch_map.armv7l == 'linux/arm/v7'
+
     - name: Render Pi-hole-only Compose configuration
       ansible.builtin.set_fact:
         pihole_only_compose: >-
@@ -34,6 +66,10 @@
         that:
           - pihole_only_compose.networks is not defined
           - pihole_only_compose.services.pihole.networks is not defined
+          - "'80:80/tcp' in pihole_only_compose.services.pihole.ports"
+          - "'443:443/tcp' in pihole_only_compose.services.pihole.ports"
+          - "'TZ=Europe/London' in pihole_only_compose.services.pihole.environment"
+          - "'FTLCONF_dns_listeningMode=ALL' in pihole_only_compose.services.pihole.environment"
           - "'FTLCONF_dns_upstreams=1.1.1.1;1.0.0.1' in pihole_only_compose.services.pihole.environment"
 
     - name: Render Pi-hole with Unbound Compose configuration

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -10,6 +10,13 @@ pihole_dir_loc: '/opt/pihole'
 pihole_compose_dir: "{{ pihole_dir_loc }}"
 pihole_image: "pihole/pihole:2026.06.0"
 pihole_firewall_deploy: "{{ lookup('ansible.builtin.vars', 'firewall_deploy', default=false) | bool }}"
+pihole_docker_platform_arch_map:
+  x86_64: linux/amd64
+  amd64: linux/amd64
+  aarch64: linux/arm64
+  arm64: linux/arm64
+  armv7l: linux/arm/v7
+  armv6l: linux/arm/v6
 
 # Deploy and integrate Unbound by default for backwards compatibility. When
 # disabled, configure at least one explicit upstream resolver below or through

--- a/roles/pihole/tasks/deploypi.yml
+++ b/roles/pihole/tasks/deploypi.yml
@@ -20,7 +20,11 @@
 - name: Pull docker image
   community.docker.docker_image_pull:
     name: "{{ pihole_image }}"
-    platform: "{{ ansible_facts['architecture'] }}"
+    platform: >-
+      {{
+        pihole_docker_platform_arch_map[ansible_facts['architecture'] | default('')]
+        | default(omit)
+      }}
 
 # Free 127.0.0.1:53 / avoid stub on 127.0.0.53 fighting Docker-published Pi-hole DNS.
 # Not gated on pihole_firewall_deploy — firewalld and resolved are separate concerns.

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -2,7 +2,11 @@
 # Main task file for Pi-hole setup using Ansible
 - name: Combine pihole_environment_variables with inventory values take precedence
   ansible.builtin.set_fact:
-    pihole_environment_variables: "{{ pihole_vars_environment_variables | default({}) | combine(pihole_environment_variables, recursive=True) }}"
+    pihole_environment_variables: >-
+      {{
+        pihole_vars_environment_variables | default({})
+        | combine(pihole_environment_variables | default({}), recursive=True)
+      }}
 
 # Inventory often sets pihole_compose_dir only; pre.yml and docker volumes use
 # pihole_dir_loc. Keep a single effective root so bind-mount paths match compose and


### PR DESCRIPTION
## Summary
- map Pi-hole image pulls from Ansible host architectures to Docker platform strings
- harden Pi-hole environment variable merging so missing user env vars do not fail and inventory overrides still win
- extend the lightweight Pi-hole mode validation playbook to cover env merging, web port rendering, and platform mappings
- document the Pi-hole Docker platform mapping behavior

## Validation
- Local Molecule tests passed, per steveyminecraft
- ansible-playbook playbooks/ci-validate-pihole-modes.yaml
- ansible-playbook --syntax-check playbooks/bootstrap-pihole.yaml
- ansible-playbook --syntax-check playbooks/update-pihole.yaml
- ansible-lint roles/pihole playbooks/ci-validate-pihole-modes.yaml playbooks/bootstrap-pihole.yaml playbooks/update-pihole.yaml
- yamllint on changed YAML files