### PR TITLE
fix(ci): clarify release please rc token handling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,12 +82,21 @@ jobs:
       && needs.release-please.outputs.release_created != 'true'
     runs-on: ubuntu-24.04
     steps:
+      - name: Validate release token for RC tagging
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN is required to push RC tags."
+            exit 1
+          fi
+
       - name: Check out release PR branch
         uses: actions/checkout@v7
         with:
           ref: release-please--branches--master
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Create and push RC tag
         env:

--- a/README.md
+++ b/README.md
@@ -482,6 +482,8 @@ PR quality scaffolding is now included in-repo:
 | [Release](.github/workflows/release-please.yml) | Push to `master` only | Release PR; tag + GitHub release + Galaxy publish when the Release PR merges |
 | [Validate collection for Ansible Galaxy](.github/workflows/galaxy-publish.yml) | Push/PR to `master`, manual | Builds the collection artifact and runs `galaxy-importer` |
 
+The Release workflow requires repository secret **`RELEASE_PLEASE_TOKEN`** for
+opening release PRs and pushing RC tags used by AWS remote tests.
 Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
 
 **Install a specific version**:


### PR DESCRIPTION
## Summary
- remove the release PAT from the release-please branch checkout so checkout can use the built-in GitHub token
- add an explicit pre-check before RC tagging so a missing RELEASE_PLEASE_TOKEN fails with a clear error
- document RELEASE_PLEASE_TOKEN as part of the release workflow setup

## Why
The post-merge Release workflow failed in run https://github.com/steveyminecraft/ansible-pihole/actions/runs/28744725023 because actions/checkout@v7 received an empty token while checking out release-please--branches--master. The job should not need the PAT for checkout; the PAT is only required for pushing RC tags.

## Validation
- yamllint .github/workflows/release-please.yml
- actionlint was not available locally; GitHub Actions will validate workflow syntax on this PR