### PR TITLE
fix(ci): skip rc tagging without release token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,22 +83,27 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Validate release token for RC tagging
+        id: rc-token
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::RELEASE_PLEASE_TOKEN is required to push RC tags."
-            exit 1
+            echo "::warning::RELEASE_PLEASE_TOKEN is not available; skipping RC tag and AWS RC tests."
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            exit 0
           fi
+          echo "available=true" >> "${GITHUB_OUTPUT}"
 
       - name: Check out release PR branch
+        if: steps.rc-token.outputs.available == 'true'
         uses: actions/checkout@v7
         with:
           ref: release-please--branches--master
           fetch-depth: 0
 
       - name: Create and push RC tag
+        if: steps.rc-token.outputs.available == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -482,8 +482,9 @@ PR quality scaffolding is now included in-repo:
 | [Release](.github/workflows/release-please.yml) | Push to `master` only | Release PR; tag + GitHub release + Galaxy publish when the Release PR merges |
 | [Validate collection for Ansible Galaxy](.github/workflows/galaxy-publish.yml) | Push/PR to `master`, manual | Builds the collection artifact and runs `galaxy-importer` |
 
-The Release workflow requires repository secret **`RELEASE_PLEASE_TOKEN`** for
-opening release PRs and pushing RC tags used by AWS remote tests.
+The Release workflow uses repository secret **`RELEASE_PLEASE_TOKEN`** for
+opening release PRs and pushing RC tags used by AWS remote tests. If the token
+is unavailable, RC tagging and AWS RC tests are skipped with a warning.
 Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
 
 **Install a specific version**:


### PR DESCRIPTION
## Summary
- make RC tagging skip with a warning when RELEASE_PLEASE_TOKEN is unavailable at runtime
- gate release-please branch checkout and RC tag creation on the token check output
- document that missing RELEASE_PLEASE_TOKEN skips RC tagging and AWS RC tests

## Why
The follow-up Release run still failed after PR #140 because GitHub evaluated secrets.RELEASE_PLEASE_TOKEN as empty in the master push workflow: https://github.com/steveyminecraft/ansible-pihole/actions/runs/28745104523

Since the token is unavailable to the workflow at runtime, the release job cannot push RC tags. This keeps the Release workflow green while making the skipped RC/AWS behavior explicit in logs.

## Validation
- yamllint .github/workflows/release-please.yml