### PR TITLE
fix(pihole): harden phase two defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,9 @@ content. It also uploads code-scanning SARIF for every default deployed
 container image; image scans are report-only because those findings belong to
 upstream images we do not build in this repository. Image targets are derived
 from role defaults by `scripts/default-container-images.py`, so changing a
-default pin updates the scan matrix without duplicating image names.
+default pin updates the scan matrix without duplicating image names. The
+GitHub matrix may also include retired image pins when GitHub code scanning
+still expects those historical Trivy categories during PR alert comparison.
 The scheduled weekly scan keeps upstream findings visible for periodic triage;
 persistent Critical findings should trigger a pinned-image upgrade review.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ Pi-hole image pulls map common host architectures to Docker platform strings via
 `armv6l` -> `linux/arm/v6`). Unknown architectures omit the platform argument
 and let Docker choose the best matching image.
 
+DNS health checks use `pihole_verify_qname` (default `cloudflare.com`) in
+Pi-hole, Unbound, Molecule, and HA verification paths. The older
+`pihole_unbound_verify_qname` remains as a compatibility alias.
+
+Pi-hole container Linux capabilities are controlled by `pihole_container_cap_add`.
+The defaults preserve existing behavior (`NET_ADMIN`, `SYS_TIME`, `SYS_NICE`,
+`CAP_NET_BIND_SERVICE`, `CAP_NET_RAW`, `CAP_CHOWN`). Override with a smaller list
+only after validating the required Pi-hole features in your deployment mode.
+
 Security defaults:
 
 - `FTLCONF_webserver_api_password` must be provided from inventory/vault and should be at least 16 characters.
@@ -253,7 +262,7 @@ Deploy or adjust keepalived HA between Pi-hole instances. Priorities and VIPs ar
 
 Deploy [Nebula Sync](https://github.com/lovelaze/nebula-sync) on the **`nebula_sync_controller`** inventory group only (one orchestrator per primary→replica topology). Lab inventories define that group in [`inventory/vagrant.yml`](inventory/vagrant.yml) with `vagrant-pihole-01` as controller. The role defaults to pinned tag `v0.11.1`; override `nebula_sync_image_tag` to test a different version.
 
-Nebula Sync defaults `nebula_sync_use_secret_files: true` so `PRIMARY` and `REPLICAS` credentials are written to mounted secret files (`PRIMARY_FILE` / `REPLICAS_FILE`) instead of plain env values where possible. The role defaults ownership to UID/GID `1001`, matching the upstream container user, and rejects placeholder credentials by default.
+Nebula Sync defaults `nebula_sync_use_secret_files: true` so `PRIMARY` and `REPLICAS` credentials are written to mounted secret files (`PRIMARY_FILE` / `REPLICAS_FILE`) instead of plain env values where possible. The service directory, compose file, and optional `.env` file default to `root:root` ownership with non-world-readable modes. Secret files remain owned by UID/GID `1001` with mode `0400`, matching the upstream container user, and placeholder credentials are rejected by default.
 
 ### Playbook tags
 

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -28,7 +28,7 @@
 
 ## Post-restore checks
 
-- `dig +short @<node-ip> google.com`
-- `dig +short @<vip-ip> google.com`
+- `dig +short @<node-ip> <pihole_verify_qname>`
+- `dig +short @<vip-ip> <pihole_verify_qname>`
 - Keepalived service running on both nodes.
 - Nebula Sync containers running and pointed at expected endpoints.

--- a/docs/failover-testing.md
+++ b/docs/failover-testing.md
@@ -23,14 +23,14 @@ molecule test -s ubuntu
 1. Query each node directly:
 
    ```bash
-   dig +short @<node1-ip> google.com
-   dig +short @<node2-ip> google.com
+   dig +short @<node1-ip> <pihole_verify_qname>
+   dig +short @<node2-ip> <pihole_verify_qname>
    ```
 
 2. Query VIP:
 
    ```bash
-   dig +short @<vip-ip> google.com
+   dig +short @<vip-ip> <pihole_verify_qname>
    ```
 
 3. Simulate primary outage (maintenance window) and confirm VIP moves to backup.

--- a/docs/upgrade-runbook.md
+++ b/docs/upgrade-runbook.md
@@ -21,7 +21,7 @@ Upgrade packages and roles while keeping DNS service available through rolling u
 4. Verify VIP answers DNS after run:
 
    ```bash
-   dig +short @<vip-ip> google.com
+   dig +short @<vip-ip> <pihole_verify_qname>
    ```
 
 ## Rollback notes

--- a/molecule/common/verify/dns.yml
+++ b/molecule/common/verify/dns.yml
@@ -1,6 +1,11 @@
 ---
 - name: Resolve via local Pi-hole on each node
-  ansible.builtin.command: dig +short @127.0.0.1 google.com
+  ansible.builtin.command:
+    argv:
+      - dig
+      - +short
+      - "@127.0.0.1"
+      - "{{ molecule_dns_verify_qname }}"
   register: dns_local
   changed_when: false
   failed_when: dns_local.stdout == ""
@@ -15,7 +20,12 @@
     fail_msg: "Local DNS did not return an IPv4."
 
 - name: Resolve via VIP (run once on first host)
-  ansible.builtin.command: dig +short @{{ vip_address }} google.com
+  ansible.builtin.command:
+    argv:
+      - dig
+      - +short
+      - "@{{ vip_address }}"
+      - "{{ molecule_dns_verify_qname }}"
   register: dns_vip
   changed_when: false
   failed_when: dns_vip.stdout == ""

--- a/molecule/common/verify/nebula_sync.yml
+++ b/molecule/common/verify/nebula_sync.yml
@@ -62,6 +62,49 @@
     - inventory_hostname == nebula_sync_controller_host
     - nebula_sync_use_env_file | default(true) | bool
 
+- name: Stat Nebula Sync service directory
+  ansible.builtin.stat:
+    path: "{{ nebula_sync_host_dir }}"
+  register: nebula_sync_dir_stat
+  when:
+    - nebula_sync_primary_url is defined
+    - inventory_hostname == nebula_sync_controller_host
+
+- name: Stat Nebula Sync compose file
+  ansible.builtin.stat:
+    path: "{{ nebula_sync_compose_host_path }}"
+  register: nebula_sync_compose_file_stat
+  when:
+    - nebula_sync_primary_url is defined
+    - inventory_hostname == nebula_sync_controller_host
+
+- name: Assert Nebula Sync service files are not world-readable
+  ansible.builtin.assert:
+    that:
+      - nebula_sync_dir_stat.stat.exists | default(false)
+      - nebula_sync_dir_stat.stat.pw_name == (nebula_sync_config_owner | default('root'))
+      - nebula_sync_dir_stat.stat.gr_name == (nebula_sync_config_group | default('root'))
+      - nebula_sync_dir_stat.stat.mode == (nebula_sync_config_dir_mode | default('0750'))
+      - nebula_sync_compose_file_stat.stat.exists | default(false)
+      - nebula_sync_compose_file_stat.stat.pw_name == (nebula_sync_config_owner | default('root'))
+      - nebula_sync_compose_file_stat.stat.gr_name == (nebula_sync_config_group | default('root'))
+      - nebula_sync_compose_file_stat.stat.mode == (nebula_sync_compose_file_mode | default('0600'))
+      - >-
+        (not (nebula_sync_use_env_file | default(true) | bool))
+        or
+        (
+          (nebula_sync_env_file_stat.stat.exists | default(false))
+          and nebula_sync_env_file_stat.stat.pw_name == (nebula_sync_config_owner | default('root'))
+          and nebula_sync_env_file_stat.stat.gr_name == (nebula_sync_config_group | default('root'))
+          and nebula_sync_env_file_stat.stat.mode == (nebula_sync_env_file_mode | default('0600'))
+        )
+    fail_msg: >-
+      Nebula Sync service directory, compose file, or env file has unexpected
+      ownership or permissions.
+  when:
+    - nebula_sync_primary_url is defined
+    - inventory_hostname == nebula_sync_controller_host
+
 - name: Read Nebula Sync env file
   no_log: true
   ansible.builtin.slurp:

--- a/molecule/common/verify_ha.yml
+++ b/molecule/common/verify_ha.yml
@@ -14,9 +14,13 @@
     nebula_sync_test_list_url: "https://example.invalid/nebula-sync-test.txt"
     nebula_sync_test_list_url_legacy: "https://example.invalid/nebula-sync-test.txt"
     nebula_sync_test_list_comment: molecule-nebula-sync-test
+    molecule_dns_verify_qname: >-
+      {{ pihole_verify_qname | default(pihole_unbound_verify_qname | default('cloudflare.com')) }}
     pihole_api_password: "{{ pihole_environment_variables.FTLCONF_webserver_api_password }}"
     nebula_sync_replica_api_url: "{{ nebula_sync_replicas[0].url }}"
     nebula_sync_secret_host_dir: "{{ nebula_sync_secret_dir | default((nebula_sync_dir | default('/opt/nebula-sync')) ~ '/secrets') }}"
+    nebula_sync_host_dir: "{{ nebula_sync_dir | default('/opt/nebula-sync') }}"
+    nebula_sync_compose_host_path: "{{ nebula_sync_host_dir }}/docker-compose.yml"
     nebula_sync_env_host_path: >-
       {{ (nebula_sync_dir | default('/opt/nebula-sync')) ~ '/' ~ (nebula_sync_env_filename | default('.env')) }}
     nebula_sync_primary_secret_container_path: >-

--- a/playbooks/bootstrap-pihole.yaml
+++ b/playbooks/bootstrap-pihole.yaml
@@ -5,7 +5,8 @@
   serial: 1
   any_errors_fatal: true
   vars:
-    pihole_bootstrap_health_qname: "{{ pihole_unbound_verify_qname | default('google.com') }}"
+    pihole_bootstrap_health_qname: >-
+      {{ pihole_verify_qname | default(pihole_unbound_verify_qname | default('cloudflare.com')) }}
     keepalived_defer_service_restart: true
   roles:
     - role: steveyminecraft.pihole.stop_keepalived
@@ -92,7 +93,11 @@
           - dig
           - +short
           - "@{{ (pihole_vip_ipv4 | split('/'))[0] }}"
-          - "{{ pihole_bootstrap_health_qname | default(pihole_unbound_verify_qname | default('google.com')) }}"
+          - >-
+            {{
+              pihole_bootstrap_health_qname
+              | default(pihole_verify_qname | default(pihole_unbound_verify_qname | default('cloudflare.com')))
+            }}
       register: pihole_bootstrap_vip_dns
       changed_when: false
       retries: 30

--- a/playbooks/ci-validate-pihole-modes.yaml
+++ b/playbooks/ci-validate-pihole-modes.yaml
@@ -13,6 +13,9 @@
     pihole_docker_dns: []
     pihole_webport_http: "80"
     pihole_webport_https: "443"
+    pihole_container_cap_add:
+      - NET_ADMIN
+      - CAP_NET_BIND_SERVICE
     pihole_docker_platform_arch_map:
       x86_64: linux/amd64
       amd64: linux/amd64
@@ -68,9 +71,30 @@
           - pihole_only_compose.services.pihole.networks is not defined
           - "'80:80/tcp' in pihole_only_compose.services.pihole.ports"
           - "'443:443/tcp' in pihole_only_compose.services.pihole.ports"
+          - pihole_only_compose.services.pihole.cap_add == pihole_container_cap_add
           - "'TZ=Europe/London' in pihole_only_compose.services.pihole.environment"
           - "'FTLCONF_dns_listeningMode=ALL' in pihole_only_compose.services.pihole.environment"
           - "'FTLCONF_dns_upstreams=1.1.1.1;1.0.0.1' in pihole_only_compose.services.pihole.environment"
+
+    - name: Render Pi-hole-only Compose configuration without extra capabilities
+      ansible.builtin.set_fact:
+        pihole_no_caps_compose: >-
+          {{
+            lookup(
+              'ansible.builtin.template',
+              playbook_dir ~ '/../roles/pihole/templates/docker-compose.yml.j2',
+              template_vars={
+                'pihole_enable_unbound': false,
+                'pihole_container_cap_add': []
+              }
+            )
+            | from_yaml
+          }}
+
+    - name: Assert empty Pi-hole capability list omits cap_add
+      ansible.builtin.assert:
+        that:
+          - pihole_no_caps_compose.services.pihole.cap_add is not defined
 
     - name: Render Pi-hole with Unbound Compose configuration
       ansible.builtin.set_fact:

--- a/playbooks/update-pihole.yaml
+++ b/playbooks/update-pihole.yaml
@@ -5,7 +5,8 @@
   serial: 1
   any_errors_fatal: true
   vars:
-    pihole_update_health_qname: "{{ pihole_unbound_verify_qname | default('google.com') }}"
+    pihole_update_health_qname: >-
+      {{ pihole_verify_qname | default(pihole_unbound_verify_qname | default('cloudflare.com')) }}
   roles:
     - role: steveyminecraft.pihole.stop_keepalived
       tags: [stopkeepalived, drain, ha]
@@ -80,7 +81,11 @@
           - dig
           - +short
           - "@{{ (pihole_vip_ipv4 | split('/'))[0] }}"
-          - "{{ pihole_update_health_qname | default(pihole_unbound_verify_qname | default('google.com')) }}"
+          - >-
+            {{
+              pihole_update_health_qname
+              | default(pihole_verify_qname | default(pihole_unbound_verify_qname | default('cloudflare.com')))
+            }}
       register: pihole_update_vip_dns
       changed_when: false
       retries: 30

--- a/roles/nebula_sync/defaults/main.yml
+++ b/roles/nebula_sync/defaults/main.yml
@@ -2,6 +2,11 @@
 # Where to deploy the compose project
 nebula_sync_dir: /opt/nebula-sync
 nebula_sync_compose_name: nebula-sync
+nebula_sync_config_owner: root
+nebula_sync_config_group: root
+nebula_sync_config_dir_mode: "0750"
+nebula_sync_compose_file_mode: "0600"
+nebula_sync_env_file_mode: "0600"
 
 # Image (GHCR)
 nebula_sync_image: "ghcr.io/lovelaze/nebula-sync"

--- a/roles/nebula_sync/tasks/main.yml
+++ b/roles/nebula_sync/tasks/main.yml
@@ -27,9 +27,9 @@
   ansible.builtin.file:
     path: "{{ nebula_sync_dir }}"
     state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0755'
+    owner: "{{ nebula_sync_config_owner }}"
+    group: "{{ nebula_sync_config_group }}"
+    mode: "{{ nebula_sync_config_dir_mode }}"
 
 - name: Ensure nebula-sync secrets directory exists
   when: nebula_sync_use_secret_files | bool
@@ -67,9 +67,9 @@
   ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: "{{ nebula_sync_dir }}/docker-compose.yml"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0644'
+    owner: "{{ nebula_sync_config_owner }}"
+    group: "{{ nebula_sync_config_group }}"
+    mode: "{{ nebula_sync_compose_file_mode }}"
   register: nebula_sync_compose_template
 
 - name: Render .env when enabled
@@ -78,9 +78,9 @@
   ansible.builtin.template:
     src: env.j2
     dest: "{{ nebula_sync_dir }}/{{ nebula_sync_env_filename }}"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: "0600"
+    owner: "{{ nebula_sync_config_owner }}"
+    group: "{{ nebula_sync_config_group }}"
+    mode: "{{ nebula_sync_env_file_mode }}"
   register: nebula_sync_env_template
 
 - name: Pull docker image

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -53,6 +53,17 @@ pihole_use_host_network: false
 # a Pi-hole app-container recreation on otherwise unchanged runs.
 pihole_force_recreate: false
 
+# Linux capabilities granted to the Pi-hole container. Defaults preserve the
+# existing role behavior; reduce this list only after validating your Pi-hole
+# mode does not need DHCP, low-port binding, or runtime tuning capabilities.
+pihole_container_cap_add:
+  - NET_ADMIN
+  - SYS_TIME
+  - SYS_NICE
+  - CAP_NET_BIND_SERVICE
+  - CAP_NET_RAW
+  - CAP_CHOWN
+
 # When true on Debian/Ubuntu, disable systemd-resolved stub DNS so host port 53 can be used
 # by Docker (Pi-hole publish). Independent of firewalld — do not tie this to pihole_firewall_deploy.
 pihole_configure_systemd_resolved: true
@@ -86,5 +97,7 @@ pihole_docker_dns: []
 pihole_override_container_resolver: false
 pihole_startup_dns: []
 
-# QNAME used in Unbound integration checks (from host / from Pi-hole container)
+# Backwards-compatible older name for inventories that already override it.
 pihole_unbound_verify_qname: "cloudflare.com"
+# QNAME used in Pi-hole, Unbound, and HA DNS verification checks.
+pihole_verify_qname: "{{ pihole_unbound_verify_qname }}"

--- a/roles/pihole/tasks/unbound.yml
+++ b/roles/pihole/tasks/unbound.yml
@@ -171,6 +171,8 @@
   when: pihole_unbound_present
 
 - name: From host, verify Unbound answers on published loopback port (if enabled)
+  vars:
+    _pihole_verify_qname: "{{ pihole_verify_qname | default('cloudflare.com') }}"
   ansible.builtin.command:
     argv:
       - dig
@@ -179,7 +181,7 @@
       - +short
       - +time=3
       - +tries=2
-      - "{{ pihole_unbound_verify_qname | default('cloudflare.com') }}"
+      - "{{ _pihole_verify_qname }}"
       - "@127.0.0.1"
   register: pihole_host_unbound_dig
   changed_when: false
@@ -223,6 +225,8 @@
   when: pihole_unbound_present
 
 - name: From host, dig Unbound on its container IPv4
+  vars:
+    _pihole_verify_qname: "{{ pihole_verify_qname | default('cloudflare.com') }}"
   ansible.builtin.command:
     argv:
       - dig
@@ -231,7 +235,7 @@
       - +short
       - +time=3
       - +tries=2
-      - "{{ pihole_unbound_verify_qname }}"
+      - "{{ _pihole_verify_qname }}"
       - "@{{ pihole_unbound_container_ipv4 }}"
   register: pihole_host_unbound_dig_bridge
   changed_when: false
@@ -282,9 +286,10 @@
   vars:
     _pihole_unbound_dig_target: >-
       {{ pihole_unbound_dns_target | default(unbound_container_name | default('unbound')) }}
+    _pihole_verify_qname: "{{ pihole_verify_qname | default('cloudflare.com') }}"
   ansible.builtin.command: >
     docker exec {{ pihole_container_name | default('pihole') }}
-    sh -lc "dig @{{ _pihole_unbound_dig_target }} -p {{ unbound_port | default(5335) }} {{ pihole_unbound_verify_qname }} +short"
+    sh -lc "dig @{{ _pihole_unbound_dig_target }} -p {{ unbound_port | default(5335) }} {{ _pihole_verify_qname }} +short"
   register: pihole_unbound_dns_test
   changed_when: false
   failed_when: >
@@ -295,9 +300,11 @@
   when: pihole_unbound_present
 
 - name: Verify Pi-hole answers DNS queries (through its local DNS)
+  vars:
+    _pihole_verify_qname: "{{ pihole_verify_qname | default('cloudflare.com') }}"
   ansible.builtin.command: >
     docker exec {{ pihole_container_name | default('pihole') }}
-    sh -lc "dig @127.0.0.1 -p 53 {{ pihole_unbound_verify_qname }} +short +tries=1 +time=2"
+    sh -lc "dig @127.0.0.1 -p 53 {{ _pihole_verify_qname }} +short +tries=1 +time=2"
   register: pihole_dns_test
   retries: 60
   delay: 2

--- a/roles/pihole/tasks/verify.yml
+++ b/roles/pihole/tasks/verify.yml
@@ -12,21 +12,35 @@
     fail_msg: "Pi-hole container is not running."
     success_msg: "Pi-hole container is running."
 
-- name: DNS test for google.com via local Pi-hole
+- name: DNS test for configured qname via local Pi-hole
+  vars:
+    _pihole_verify_qname: "{{ pihole_verify_qname | default('cloudflare.com') }}"
   ansible.builtin.command:
-    cmd: dig +short google.com @127.0.0.1 +timeout=3 +tries=2
-  register: pihole_dns_test_google
+    argv:
+      - dig
+      - +short
+      - "{{ _pihole_verify_qname }}"
+      - "@127.0.0.1"
+      - +timeout=3
+      - +tries=2
+  register: pihole_dns_test_verify
   changed_when: false
   failed_when: false
   retries: 18
   delay: 5
-  until: (pihole_dns_test_google.rc | default(1)) == 0 and (pihole_dns_test_google.stdout | default('') | trim | length > 0)
+  until: (pihole_dns_test_verify.rc | default(1)) == 0 and (pihole_dns_test_verify.stdout | default('') | trim | length > 0)
 
-- name: Assert google.com result looks like valid IPv4
+- name: Assert configured qname result looks like valid IPv4
+  vars:
+    _pihole_verify_qname: "{{ pihole_verify_qname | default('cloudflare.com') }}"
   ansible.builtin.assert:
     that:
-      - pihole_dns_test_google.stdout_lines | length > 0
-      - pihole_dns_test_google.stdout_lines | select(
+      - pihole_dns_test_verify.stdout_lines | length > 0
+      - pihole_dns_test_verify.stdout_lines | select(
           'match', '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$'
         ) | list | length > 0
-    fail_msg: "DNS did not return at least one valid IPv4 for google.com via Pi-hole:\n{{ pihole_dns_test_google.stdout }}"
+    fail_msg: >-
+      DNS did not return at least one valid IPv4 for
+      {{ _pihole_verify_qname }}
+      via Pi-hole:
+      {{ pihole_dns_test_verify.stdout }}

--- a/roles/pihole/templates/docker-compose.yml.j2
+++ b/roles/pihole/templates/docker-compose.yml.j2
@@ -22,13 +22,12 @@ services:
     volumes:
       - {{ pihole_dir_loc }}/etc/pihole:/etc/pihole
       - {{ pihole_dir_loc }}/etc/dnsmasq.d:/etc/dnsmasq.d
+{% if pihole_container_cap_add | default([]) | length > 0 %}
     cap_add:
-      - NET_ADMIN
-      - SYS_TIME
-      - SYS_NICE
-      - CAP_NET_BIND_SERVICE
-      - CAP_NET_RAW
-      - CAP_CHOWN
+{% for cap in pihole_container_cap_add %}
+      - {{ cap }}
+{% endfor %}
+{% endif %}
 {% if pihole_rocky_network_debug | default(false) | bool %}
     privileged: true
     security_opt:

--- a/scripts/default-container-images.py
+++ b/scripts/default-container-images.py
@@ -13,6 +13,14 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# GitHub code scanning keeps historical default-branch Trivy configurations in
+# PR comparisons even after the deployed default image is bumped. Keep retired
+# categories here until the repository security state no longer reports them as
+# required for PR alert comparison.
+LEGACY_CODE_SCANNING_IMAGES = (
+    "pihole/pihole:2026.05.0",
+)
+
 
 def load_defaults(role: str) -> dict:
     path = ROOT / "roles" / role / "defaults" / "main.yml"
@@ -37,6 +45,10 @@ def default_images() -> list[str]:
     return sorted(images)
 
 
+def code_scanning_images() -> list[str]:
+    return sorted({*default_images(), *LEGACY_CODE_SCANNING_IMAGES})
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -46,8 +58,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    images = default_images()
     if args.github_matrix:
+        images = code_scanning_images()
         print(
             json.dumps(
                 {
@@ -61,7 +73,7 @@ def main() -> None:
         )
         return
 
-    print("\n".join(images))
+    print("\n".join(default_images()))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_default_container_images.py
+++ b/tests/unit/test_default_container_images.py
@@ -49,6 +49,25 @@ class DefaultContainerImagesTests(unittest.TestCase):
 
         self.assertEqual([], latest_images)
 
+    def test_code_scanning_images_include_legacy_categories(self) -> None:
+        images = set(self.helper.code_scanning_images())
+
+        self.assertTrue(set(self.helper.default_images()) <= images)
+        self.assertIn("pihole/pihole:2026.05.0", images)
+
+    def test_image_key_preserves_image_tag_for_code_scanning_category(self) -> None:
+        self.assertEqual(
+            "registry.example.com-5000-team-image-v1.2.3",
+            self.helper.image_key("registry.example.com:5000/team/image:v1.2.3"),
+        )
+        self.assertEqual(
+            "ghcr.io-lovelaze-nebula-sync-sha256-0123456789abcdef",
+            self.helper.image_key(
+                "ghcr.io/lovelaze/nebula-sync"
+                "@sha256:0123456789abcdef"
+            ),
+        )
+
     def test_github_matrix_is_valid_and_has_unique_keys(self) -> None:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--github-matrix"],
@@ -58,13 +77,14 @@ class DefaultContainerImagesTests(unittest.TestCase):
         )
         matrix = json.loads(result.stdout)
         entries = matrix["include"]
+        code_scanning_images = self.helper.code_scanning_images()
 
         self.assertGreaterEqual(len(entries), 3)
-        self.assertEqual(len(entries), len(self.helper.default_images()))
+        self.assertEqual(len(entries), len(code_scanning_images))
         self.assertEqual(len({entry["key"] for entry in entries}), len(entries))
         self.assertEqual(
             {entry["image"] for entry in entries},
-            set(self.helper.default_images()),
+            set(code_scanning_images),
         )
 
 


### PR DESCRIPTION
## Summary
- make Pi-hole, Unbound, HA, and Molecule DNS verification use configurable pihole_verify_qname while keeping pihole_unbound_verify_qname as a compatibility alias
- add pihole_container_cap_add so Pi-hole container capabilities can be reduced or omitted without editing the template
- harden Nebula Sync service file ownership and permissions, with Molecule assertions and documentation updates

## Validation
- yamllint on changed YAML files
- ansible-playbook --syntax-check for bootstrap-pihole, update-pihole, sync, and ci-validate-pihole-modes
- ansible-playbook playbooks/ci-validate-pihole-modes.yaml
- ansible-lint roles/pihole roles/nebula_sync playbooks/bootstrap-pihole.yaml playbooks/update-pihole.yaml playbooks/sync.yaml playbooks/ci-validate-pihole-modes.yaml molecule/common/verify_ha.yml
- local Molecule tests reported passing before publish