### PR TITLE
feat: add local graphify knowledge vault for agent context

### DIFF
--- a/.cursor/rules/graphify-knowledge-base.mdc
+++ b/.cursor/rules/graphify-knowledge-base.mdc
@@ -1,0 +1,35 @@
+---
+description: Local graphify knowledge vault — query before explore, bootstrap when missing
+alwaysApply: true
+---
+
+# Knowledge vault (local graphify)
+
+`graphify-out/` is **gitignored** and generated per machine. Read `docs/knowledge-vault.md` for the full guide.
+
+## Bootstrap (graph missing)
+
+If `graphify-out/graph.json` does not exist:
+
+1. Run `./scripts/setup-knowledge-vault.sh` from the repo root (fast code graph, no API key).
+2. For **full** coverage (Ansible YAML, docs, Obsidian vault), run `/graphify .` in Cursor or `./scripts/setup-knowledge-vault.sh --full` and follow the agent-driven build.
+
+Do not grep the codebase for architecture questions until bootstrap completes or you have confirmed `graph.json` exists.
+
+## Query before explore
+
+For “how does X work?”, data flow, role/playbook relationships, or cross-file dependencies:
+
+1. `graphify query "<question>"`
+2. `graphify path "<A>" "<B>"` or `graphify explain "<concept>"` when tracing a specific link
+3. Open source files only after the graph orients you
+
+Prefer `graphify-out/KNOWLEDGE_VAULT.md` (local) and `graphify-out/GRAPH_REPORT.md` for hub navigation. Obsidian vault: `graphify-out/obsidian/` (human browsing; agents use `graphify query`).
+
+## Keep local graph fresh
+
+After changing **code** (`.py`, `.sh`): `graphify update .` (AST-only, no API cost).
+
+After changing **docs, roles, playbooks, or inventories**: re-run `/graphify .` or `graphify update .` plus a full rebuild when the graph feels stale.
+
+Optional: `graphify hook install` rebuilds the code graph automatically after each commit (local only).

--- a/.cursor/skills/ship-change/SKILL.md
+++ b/.cursor/skills/ship-change/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: ship-change
+description: >-
+  Branch, commit, GitHub issue (ticket), and PR for steveyminecraft/ansible-pihole.
+  Use when the user asks to ship, commit, open a ticket, create a PR, or
+  "branch commit pr ticket".
+---
+
+# Ship a change (branch → ticket → commit → PR)
+
+Follow **git-branch-workflow** and **readme-maintenance** project skills.
+
+## When the user asks to ship
+
+Run only when explicitly requested (commit/push/PR). Never force-push `master`.
+
+### 1. Refresh `master`
+
+```bash
+git fetch origin
+git checkout master
+git pull --ff-only origin master
+```
+
+If fast-forward fails, stop and ask the user.
+
+### 2. Topic branch
+
+```bash
+git checkout -b <type>/<short-kebab-description>
+```
+
+Types: `feature/`, `fix/`, `bugfix/`, `chore/`, `docs/`.
+
+### 3. GitHub issue (ticket)
+
+Create before or with the PR so the PR can link it:
+
+```bash
+gh issue create \
+  --title "<concise title>" \
+  --body "$(cat <<'EOF'
+## Problem / goal
+
+<why this change exists>
+
+## Proposed solution
+
+- <bullet>
+
+## Acceptance criteria
+
+- [ ] <checkable item>
+
+EOF
+)"
+```
+
+Note the issue number (e.g. `#140`).
+
+### 4. Commit
+
+```bash
+git status
+git diff
+git log -3 --oneline
+```
+
+Stage only relevant files. Never commit secrets (`.env`, vault blobs, `graphify-out/`).
+
+Conventional commit subject (`feat:`, `fix:`, `docs:`, `chore:`, etc.). Body explains **why**.
+
+```bash
+git add <paths>
+git commit -m "$(cat <<'EOF'
+<type>: <summary>
+
+<optional body — user-visible impact, not file list>
+
+Fixes #<issue>
+EOF
+)"
+```
+
+Use `Fixes #N` or `Closes #N` when the issue should close on merge.
+
+### 5. Push and PR
+
+```bash
+git push -u origin HEAD
+```
+
+```bash
+gh pr create \
+  --base master \
+  --title "<type>: <summary>" \
+  --body "$(cat <<'EOF'
+Fixes #<issue>
+
+## Summary
+
+- <1-3 bullets — user-visible or explicit internal-only>
+
+## Release notes
+
+- Proposed release note sentence:
+  - `<one sentence or N/A for internal-only>`
+- Changelog type:
+  - [ ] `feat`
+  - [ ] `fix`
+  - [ ] `perf`
+  - [ ] `refactor`
+  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)
+
+## Validation
+
+- [ ] ansible-lint / yamllint (or N/A)
+- [ ] syntax checks for changed playbooks/roles (or N/A)
+- [ ] Molecule / remote tests when behavior changes (or N/A)
+- [ ] README / docs updated when needed
+
+## Scope and risk
+
+- Risk level: [x] low  [ ] medium  [ ] high
+- Rollback plan: revert PR merge commit
+
+EOF
+)"
+```
+
+Return the **issue URL** and **PR URL** to the user.
+
+### 6. After merge (later)
+
+Per git-branch-workflow: delete merged topic branch locally and on origin.
+
+## Checklist
+
+```
+- [ ] master fast-forwarded from origin
+- [ ] topic branch from master
+- [ ] GitHub issue created
+- [ ] conventional commit; no secrets in diff
+- [ ] README updated if setup/behavior docs changed
+- [ ] PR targets master; links issue
+- [ ] PR body matches .github/pull_request_template.md
+```
+
+## Repo-specific notes
+
+- PRs merge to **`master`** only.
+- Release notes matter: PR title should match conventional commit format (CI checks PR titles).
+- `graphify-out/` is gitignored — never add it.

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ cython_debug/
 steveyminecraft-pihole-*.tar.gz
 inventory/inventory.yaml
 inventory/rnet.yml
+
+# graphify knowledge vault (local only — see docs/knowledge-vault.md)
+graphify-out/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,14 @@ Before opening or merging:
   ```bash
   git config --global commit.template /absolute/path/to/.github/commit-message-template.txt
   ```
+
+## Local knowledge vault (graphify)
+
+Architecture maps and agent context live under `graphify-out/` on your machine only (gitignored).
+
+```bash
+./scripts/setup-knowledge-vault.sh          # fast code graph
+./scripts/setup-knowledge-vault.sh --full   # how to run full /graphify . build
+```
+
+See `docs/knowledge-vault.md`. Cursor agents bootstrap automatically when `graph.json` is missing.

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ GitHub repository variables documented in `tests/remote/README.md`.
 - [Failover testing](docs/failover-testing.md)
 - [Backup and restore](docs/backup-and-restore.md)
 - [Secrets management](docs/secrets-management.md)
+- [Knowledge vault (local graphify)](docs/knowledge-vault.md) — optional agent architecture map; `graphify-out/` stays local
 
 ### Releases and Ansible Galaxy
 

--- a/docs/knowledge-vault.md
+++ b/docs/knowledge-vault.md
@@ -1,0 +1,84 @@
+# Knowledge vault (local graphify)
+
+This collection can be mapped with [graphify](https://github.com/safishamsi/graphify) into a **local** knowledge graph. Outputs stay on your machine under `graphify-out/` (gitignored) so nothing is pushed to GitHub.
+
+Agents and contributors use the graph for architecture questions; humans can browse the Obsidian vault or `graph.html`.
+
+## Quick start
+
+```bash
+# From repo root — installs graphify if needed, builds code graph, exports HTML/Obsidian
+./scripts/setup-knowledge-vault.sh
+
+# Optional: rebuild code graph after every commit (local only)
+graphify hook install
+```
+
+Open the interactive map: `graphify-out/graph.html`  
+Open Obsidian vault: `graphify-out/obsidian/`
+
+## What gets generated (all local)
+
+| Path | Purpose |
+|------|---------|
+| `graphify-out/graph.json` | Query target for agents (`graphify query`, MCP) |
+| `graphify-out/graph.html` | Browser visualization |
+| `graphify-out/GRAPH_REPORT.md` | God nodes, communities, surprising connections |
+| `graphify-out/KNOWLEDGE_VAULT.md` | Local entry point (copied from this doc + build stats) |
+| `graphify-out/obsidian/` | Wikilinked notes + `graph.canvas` |
+
+## Bootstrap modes
+
+### Fast (default) — no API key
+
+`./scripts/setup-knowledge-vault.sh`
+
+Runs `graphify update .`: AST extraction for Python/shell **code** only. Good for scripts and unit tests. Ansible YAML and markdown are not fully covered until a full build.
+
+### Full — docs, roles, playbooks, Obsidian
+
+`./scripts/setup-knowledge-vault.sh --full`
+
+Prints instructions to run **`/graphify .`** in Cursor (or any graphify-capable agent). That pipeline extracts all 180+ corpus files, merges semantic + AST edges, and is the same process used to produce the rich HA/role/playbook map.
+
+Optional: set `GEMINI_API_KEY` or `GOOGLE_API_KEY` for automated semantic extraction instead of agent subagents.
+
+## Agent workflow
+
+Cursor rule `.cursor/rules/graphify-knowledge-base.mdc` tells agents to:
+
+1. Check for `graphify-out/graph.json`
+2. Run `./scripts/setup-knowledge-vault.sh` if missing
+3. Use `graphify query` before `Grep`/`Read` for architecture questions
+4. Run `graphify update .` after code edits
+
+Example queries:
+
+```bash
+graphify query "How does HA failover work?"
+graphify path "playbooks/bootstrap-pihole.yaml" "nebula_sync"
+graphify explain "molecule/default/molecule.yml"
+```
+
+## Refresh after changes
+
+| Change type | Command |
+|-------------|---------|
+| Python/shell | `graphify update .` |
+| Roles, playbooks, docs | `/graphify .` or full rebuild |
+| Re-export Obsidian | `graphify export obsidian` |
+| Re-export HTML | `graphify export html` |
+
+## Security
+
+- `graphify-out/` is **not committed** — lab fixture passwords in inventory YAML stay out of any graph artifact on GitHub.
+- Graphify skips `.env`, keys, and `secrets/` paths during detection.
+- Before sharing `graphify-out/` manually, scan for accidental secrets.
+
+## Role deployment chain (reference)
+
+```
+stop_keepalived → bootstrap → updates → sshd → keepalived → docker → unbound → pihole
+```
+
+Key playbooks: `playbooks/bootstrap-pihole.yaml`, `sync.yaml`, `update-pihole.yaml`, `keepalived.yaml`.

--- a/scripts/setup-knowledge-vault.sh
+++ b/scripts/setup-knowledge-vault.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Bootstrap local graphify knowledge vault (graphify-out/ is gitignored).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FULL=0
+INSTALL_HOOK=0
+for arg in "$@"; do
+  case "$arg" in
+    --full) FULL=1 ;;
+    --hook) INSTALL_HOOK=1 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: ./scripts/setup-knowledge-vault.sh [--full] [--hook]
+
+  (default)  Install graphify if needed, run graphify update (code/AST graph),
+             export HTML + Obsidian when graph.json exists.
+  --full     Print how to run a full /graphify . build for YAML/docs coverage.
+  --hook     Also run: graphify hook install (post-commit code graph refresh).
+
+graphify-out/ is local only — not committed to git.
+See docs/knowledge-vault.md.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg (try --help)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+ensure_graphify() {
+  if command -v graphify >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    echo "Installing graphify via uv tool..."
+    uv tool install --upgrade graphifyy -q
+    return 0
+  fi
+  echo "graphify not found. Install with: uv tool install graphifyy" >&2
+  echo "Or: pip install graphifyy" >&2
+  exit 1
+}
+
+write_local_index() {
+  mkdir -p graphify-out
+  local nodes edges communities commit
+  nodes="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len(g.get('nodes',[])))" 2>/dev/null || echo '?')"
+  edges="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len(g.get('edges',[])))" 2>/dev/null || echo '?')"
+  communities="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len({n.get('community') for n in g.get('nodes',[]) if n.get('community') is not None}))" 2>/dev/null || echo '?')"
+  commit="$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+
+  {
+    cat "$ROOT/docs/knowledge-vault.md"
+    echo ""
+    echo "---"
+    echo ""
+    echo "## Local build"
+    echo ""
+    echo "- **Built:** $(date -u +%Y-%m-%d) · **Graph:** ${nodes} nodes · ${edges} edges · ${communities} communities · commit \`${commit}\`"
+    echo "- **Regenerate:** \`./scripts/setup-knowledge-vault.sh\` or \`/graphify .\` for full corpus"
+  } > graphify-out/KNOWLEDGE_VAULT.md
+
+  if [[ -d graphify-out/obsidian ]]; then
+    cp graphify-out/KNOWLEDGE_VAULT.md "graphify-out/obsidian/00 - Knowledge Vault Index.md"
+  fi
+}
+
+ensure_graphify
+
+if [[ "$FULL" -eq 1 ]]; then
+  cat <<'EOF'
+
+Full graphify build (Ansible YAML, markdown docs, rich Obsidian vault):
+
+  In Cursor, run:  /graphify .
+
+Or invoke the graphify skill on this repo root. That extracts the full corpus
+(roles, playbooks, molecule scenarios, docs) — not just Python/shell AST.
+
+Optional: export GEMINI_API_KEY for unattended semantic extraction.
+
+After the agent build finishes:
+  graphify export html
+  graphify export obsidian
+  ./scripts/setup-knowledge-vault.sh   # refresh KNOWLEDGE_VAULT.md index
+
+EOF
+  if [[ -f graphify-out/graph.json ]]; then
+    echo "graphify-out/graph.json already exists ($(wc -c < graphify-out/graph.json) bytes)."
+    echo "Delete graphify-out/ and re-run /graphify . for a clean full rebuild."
+  fi
+  exit 0
+fi
+
+echo "Building local code graph (graphify update)..."
+graphify update .
+
+write_local_index
+
+echo "Exporting HTML..."
+graphify export html
+
+if [[ -f graphify-out/graph.json ]]; then
+  echo "Exporting Obsidian vault..."
+  graphify export obsidian
+  write_local_index
+fi
+
+if [[ "$INSTALL_HOOK" -eq 1 ]]; then
+  graphify hook install
+  graphify hook status
+fi
+
+cat <<EOF
+
+Knowledge vault ready under graphify-out/ (local, gitignored).
+
+  graphify-out/graph.html
+  graphify-out/GRAPH_REPORT.md
+  graphify-out/KNOWLEDGE_VAULT.md
+  graphify-out/obsidian/
+
+For full YAML/docs coverage: ./scripts/setup-knowledge-vault.sh --full
+Docs: docs/knowledge-vault.md
+EOF


### PR DESCRIPTION
Fixes #148

## Summary

- Gitignore `graphify-out/` so graph/Obsidian artifacts stay local (not on GitHub)
- Add `docs/knowledge-vault.md` and `./scripts/setup-knowledge-vault.sh` to bootstrap a local graphify map
- Add Cursor rule instructing agents to query graphify before grep and auto-bootstrap when `graph.json` is missing
- Add `ship-change` project skill documenting branch → issue → commit → PR workflow

## Release notes

- Proposed release note sentence:
  - N/A — contributor/agent tooling only; no operator-facing runtime change
- Changelog type:
  - [ ] `feat`
  - [ ] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-lint / yamllint (N/A — no playbook/role YAML changes)
- [x] syntax checks for changed playbooks/roles (N/A)
- [x] Molecule / remote tests (N/A)
- [x] README / docs updated (`README.md`, `CONTRIBUTING.md`, `docs/knowledge-vault.md`)

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit

Made with [Cursor](https://cursor.com)