### PR TITLE
fix: bump pinned Pi-hole image to 2026.07.2

### DIFF
--- a/playbooks/ci-bootstrap.yaml
+++ b/playbooks/ci-bootstrap.yaml
@@ -19,7 +19,7 @@
 
     password_lock: false
     # Point Pi-hole image at something valid, but we're in --check anyway
-    pihole_image: "pihole/pihole:2026.06.0"
+    pihole_image: "pihole/pihole:2026.07.2"
     pihole_compose_dir: "/opt/pihole"
 
   roles:

--- a/playbooks/ci-validate-pihole-modes.yaml
+++ b/playbooks/ci-validate-pihole-modes.yaml
@@ -5,7 +5,7 @@
   gather_facts: false
   vars:
     pihole_container_name: pihole
-    pihole_image: "pihole/pihole:2026.06.0"
+    pihole_image: "pihole/pihole:2026.07.2"
     pihole_dir_loc: /opt/pihole
     pihole_network_name: dns_net
     pihole_use_host_network: false

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -8,7 +8,7 @@
 # tasks/main.yml aligns pihole_dir_loc so volume paths match the playbook.
 pihole_dir_loc: '/opt/pihole'
 pihole_compose_dir: "{{ pihole_dir_loc }}"
-pihole_image: "pihole/pihole:2026.06.0"
+pihole_image: "pihole/pihole:2026.07.2"
 pihole_firewall_deploy: "{{ lookup('ansible.builtin.vars', 'firewall_deploy', default=false) | bool }}"
 pihole_docker_platform_arch_map:
   x86_64: linux/amd64

--- a/scripts/default-container-images.py
+++ b/scripts/default-container-images.py
@@ -19,6 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 # required for PR alert comparison.
 LEGACY_CODE_SCANNING_IMAGES = (
     "pihole/pihole:2026.05.0",
+    "pihole/pihole:2026.06.0",
 )
 
 

--- a/tests/unit/test_default_container_images.py
+++ b/tests/unit/test_default_container_images.py
@@ -54,6 +54,7 @@ class DefaultContainerImagesTests(unittest.TestCase):
 
         self.assertTrue(set(self.helper.default_images()) <= images)
         self.assertIn("pihole/pihole:2026.05.0", images)
+        self.assertIn("pihole/pihole:2026.06.0", images)
 
     def test_image_key_preserves_image_tag_for_code_scanning_category(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
Fixes #151

## Summary

- Bump default `pihole_image` and mirrored CI playbook pins from `2026.06.0` to `2026.07.2`
- Retain `2026.06.0` in Trivy legacy code-scanning image categories for GitHub security alert continuity

## Release notes

- Proposed release note sentence:
  - Bump the default pinned Pi-hole container image to `2026.07.2`.
- Changelog type:
  - [ ] `feat`
  - [x] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [ ] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] `python3 scripts/validate-secure-defaults.py`
- [x] `python3 -m unittest discover -s tests/unit`
- [ ] Molecule / remote tests (image pin only; CI will validate)

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit; redeploy with previous pin if needed

Made with [Cursor](https://cursor.com)