### PR TITLE
test: add update-pihole side_effect to ubuntu Molecule HA scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Two Vagrant VMs run the real playbooks (see [`molecule/ubuntu/converge.yml`](mol
 | [`molecule/common/verify_ha.yml`](molecule/common/verify_ha.yml) | Shared verify orchestrator for focused tasks under `molecule/common/verify/` |
 | `molecule/{scenario}/` | `molecule.yml`, `Vagrantfile`, `create.yml`, `destroy.yml`, thin `prepare.yml` / `verify.yml` |
 
-**`molecule test`** sequence: **dependency** (same [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh) as above), **syntax**, **create** (`vagrant up` in the scenario directory), **prepare**, **converge**, **verify**, **destroy**. Localhost lifecycle playbooks use `chdir: "{{ playbook_dir }}"` so Vagrant runs in the right folder.
+**`molecule test`** sequence: **dependency** (same [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh) as above), **syntax**, **create** (`vagrant up` in the scenario directory), **prepare**, **converge**, **verify**, and for HA/update scenarios **side_effect** then **verify** again, then **destroy**. Localhost lifecycle playbooks use `chdir: "{{ playbook_dir }}"` so Vagrant runs in the right folder.
 
 The bundled scenarios intentionally omit Molecule's `idempotence` step because
 the HA flow drains/resumes keepalived and can restart resolver/container
@@ -310,8 +310,8 @@ instances, lab VMs, or Raspberry Pi hardware.
 
 | Scenario | Path | Platforms |
 |----------|------|-----------|
-| `ubuntu` | [`molecule/ubuntu/`](molecule/ubuntu/) | Ubuntu 24.04 (`bento/ubuntu-24.04`) |
-| `ubuntu-26.04` | [`molecule/ubuntu-26.04/`](molecule/ubuntu-26.04/) | Ubuntu 26.04 — VirtualBox: `konstruktoid/ubuntu-26.04` (Bento); libvirt: `cloud-image/ubuntu-26.04` |
+| `ubuntu` | [`molecule/ubuntu/`](molecule/ubuntu/) | Ubuntu 24.04 (`bento/ubuntu-24.04`); HA bootstrap, verify, rolling `update-pihole`, post-update verify |
+| `ubuntu-26.04` | [`molecule/ubuntu-26.04/`](molecule/ubuntu-26.04/) | Ubuntu 26.04 — VirtualBox: `konstruktoid/ubuntu-26.04` (Bento); libvirt: `cloud-image/ubuntu-26.04`; same HA + update sequence as `ubuntu` |
 | `default` | [`molecule/default/`](molecule/default/) | Rocky-style box (see `molecule.yml`) |
 | `nebula-sync-migration` | [`molecule/nebula-sync-migration/`](molecule/nebula-sync-migration/) | Seeds legacy plaintext credentials, then verifies migration to secret-file mode |
 | `pihole-no-unbound` | [`molecule/pihole-no-unbound/`](molecule/pihole-no-unbound/) | Runs bootstrap and update workflows with Pi-hole-only DNS |

--- a/docs/failover-testing.md
+++ b/docs/failover-testing.md
@@ -10,6 +10,13 @@ Run:
 molecule test -s ubuntu
 ```
 
+The `ubuntu` and `ubuntu-26.04` scenarios run a full test sequence:
+
+1. **Converge** — bootstrap the HA stack
+2. **Verify** — baseline HA / DNS checks (`verify_ha.yml`)
+3. **Side effect** — rolling `playbooks/update-pihole.yaml` (drain → update → resume)
+4. **Verify** — post-update HA / DNS checks (`verify_ha.yml`)
+
 `molecule/common/verify_ha.yml` orchestrates focused verifier task files under
 `molecule/common/verify/` and validates:
 

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -1,0 +1,137 @@
+# Improvement Backlog
+
+Action items identified from a project review (2026-07-09). Use this as a
+prioritized checklist when planning issues or PRs.
+
+## Priority 1 — Testing (highest impact)
+
+The repo has a three-layer test model (GitHub CI → Molecule/Vagrant → AWS
+remote), but coverage is uneven on the riskiest path: rolling HA updates.
+
+- [x] **Add `update-pihole` to the HA Molecule path** ([#153](https://github.com/steveyminecraft/ansible-pihole/issues/153))
+  - Today only `molecule/pihole-no-unbound` runs it via `side_effect.yml`.
+  - Main `ubuntu` scenario exercises failover (`molecule/common/verify_ha.yml`)
+    but never rolls an update.
+  - Suggested: add `side_effect.yml` to `molecule/ubuntu` importing
+    `playbooks/update-pihole.yaml`, then extend HA verify post-update.
+
+- [ ] **Scheduled or label-triggered AWS remote tests**
+  - `aws-remote-tests.yml` is manual `workflow_dispatch` only.
+  - Options: nightly/weekly on `master`, or PR label `run-aws-tests`.
+  - Start with amd64-only, `pihole-unbound`, include update (not `--skip-update`).
+
+- [ ] **Check-mode for `update-pihole.yaml` in CI**
+  - CI already runs check-mode for `ci-bootstrap.yaml`.
+  - Add syntax + `--check` for `playbooks/update-pihole.yaml` against
+    `inventory/ci/ci.yml`.
+
+- [ ] **Expand unit/integration tests beyond scripts**
+  - Current unit tests: `default-container-images`, upstream image check, AWS
+    cleanup scripts.
+  - Gaps: playbook health-gate logic, rolling serial behavior, rendered
+    templates.
+  - Consider lightweight `ansible-test` or expression-level tests for
+    `failed_when` blocks in `update-pihole.yaml`.
+
+## Priority 2 — Operations documentation
+
+Docs are clear at a high level but thin relative to playbook complexity.
+
+- [ ] **Document `update-pihole.yaml` health gates**
+  - Cover: local DNS wait, Unbound check, VIP verify, keepalived resume.
+  - Include: what fails, expected timing, retry guidance.
+
+- [ ] **Expand stub role READMEs**
+  - Thin today: `start_keepalived`, `stop_keepalived`, `sshd`, `nebula_sync`.
+  - Document drain/resume pattern, when each role runs, relevant tags.
+
+- [ ] **Cross-link production change runbooks**
+  - Chain: `upgrade-runbook.md` → `failover-testing.md` →
+    `backup-and-restore.md` as a single checklist (backup → update → VIP →
+    Nebula sync verify).
+
+## Priority 3 — Inventory and secrets ergonomics
+
+Real inventory (`inventory/rnet.yml`) is gitignored; examples exist but mapping
+is implicit.
+
+- [ ] **Document real inventory → example mapping**
+  - In `docs/production-deployment.md`: required vs optional vars, vault file
+    layout, HA-specific fields (`pihole_vip_ipv4`, nebula primary/replicas).
+
+- [ ] **Expand `docs/secrets-management.md`**
+  - Vault naming convention, Nebula Sync password rotation, drift between nodes.
+
+- [ ] **Pre-flight inventory validator**
+  - Playbook or script asserting HA completeness and rejecting placeholders
+    before bootstrap/update (fail fast vs mid-deploy).
+
+## Priority 4 — Image and dependency maintenance
+
+Image bumps currently touch multiple files manually (defaults, CI playbooks,
+Trivy legacy list).
+
+- [ ] **Wire upstream image check into CI**
+  - `tests/unit/test_check_pihole_image_upstream.py` exists; run in CI
+    (informational or blocking on drift).
+
+- [ ] **Single source of truth for image pin**
+  - Generate CI inventory pins from `roles/pihole/defaults/main.yml` (or
+    reverse) so bumps are one-line changes.
+
+## Priority 5 — Developer experience (knowledge vault)
+
+Local graphify setup is valuable; graph quality can be improved.
+
+- [ ] **Install `graphify hook`** for post-commit auto-update
+  - See `docs/knowledge-vault.md` and `./scripts/setup-knowledge-vault.sh`.
+
+- [ ] **Reduce graph noise**
+  - ~405 isolated nodes; duplicate concepts (e.g. `update-pihole.yaml` vs
+    `update-pihole playbook`). Periodic full rebuild + dedupe pass.
+
+- [ ] **Optional: graphify MCP server**
+  - Lets Cursor/agents query the graph without shelling out.
+
+## Priority 6 — Architecture hygiene (medium-term)
+
+- [ ] **Legacy unprefixed variable deprecation**
+  - README documents compatibility lookups; add deprecation timeline + lint
+    warning for unprefixed names (prefer `pihole_*`).
+
+- [ ] **Unified testing index**
+  - New or expanded `docs/testing.md`: CI / Molecule / AWS / manual checks in
+    one page (graph suggested splits: Remote HA Inventories, Failover
+    Verification, Molecule scenarios).
+
+## Priority 7 — CI polish (lower effort)
+
+- [ ] **Molecule in CI alternatives**
+  - Vanilla GitHub runners can't run Vagrant easily.
+  - Options: self-hosted runner, or smoke job on `molecule/docker` (no Vagrant).
+
+- [ ] **PR template checkbox for HA changes**
+  - Add: "Ran `molecule test -s ubuntu` locally" for HA-touching PRs.
+
+---
+
+## Quick reference — current test coverage
+
+| Layer | Runs today | Gap |
+|-------|------------|-----|
+| GitHub CI | Lint, syntax, check-mode bootstrap, compose validation | No functional HA or update path |
+| Molecule | 6 scenarios locally; HA verify on `ubuntu` | Not in CI; `update-pihole` in `ubuntu`, `ubuntu-26.04`, and `pihole-no-unbound` |
+| AWS remote | Bootstrap + optional `update-pihole` | Manual dispatch only |
+
+## Suggested first issues
+
+1. `ubuntu` Molecule side_effect for `update-pihole` + post-update HA verify
+2. Scheduled AWS remote test on `master` (weekly, amd64)
+3. Runbook section for rolling updates / drain-resume
+4. Inventory pre-flight validator
+5. Upstream image check in CI
+
+---
+
+*Generated from project review. Update checkboxes as items ship; link PR/issue
+numbers inline when work starts.*

--- a/molecule/ubuntu-26.04/molecule.yml
+++ b/molecule/ubuntu-26.04/molecule.yml
@@ -41,6 +41,7 @@ provisioner:
     create: create.yml
     prepare: prepare.yml
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
     destroy: destroy.yml
   env:
@@ -57,5 +58,7 @@ scenario:
     - create
     - prepare
     - converge
+    - verify
+    - side_effect
     - verify
     - destroy

--- a/molecule/ubuntu-26.04/side_effect.yml
+++ b/molecule/ubuntu-26.04/side_effect.yml
@@ -1,0 +1,3 @@
+---
+- name: Exercise rolling HA update workflow
+  import_playbook: ../../playbooks/update-pihole.yaml

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -40,6 +40,7 @@ provisioner:
     create: create.yml
     prepare: prepare.yml
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
     destroy: destroy.yml
   env:
@@ -56,5 +57,7 @@ scenario:
     - create
     - prepare
     - converge
+    - verify
+    - side_effect
     - verify
     - destroy

--- a/molecule/ubuntu/side_effect.yml
+++ b/molecule/ubuntu/side_effect.yml
@@ -1,0 +1,3 @@
+---
+- name: Exercise rolling HA update workflow
+  import_playbook: ../../playbooks/update-pihole.yaml


### PR DESCRIPTION
Fixes #153

## Summary

- Add `side_effect.yml` to `molecule/ubuntu` and `molecule/ubuntu-26.04` importing `playbooks/update-pihole.yaml`
- Extend test sequence: converge → verify → side_effect (rolling update) → verify
- Document HA + update flow in `docs/failover-testing.md`, README, and `docs/improvement-backlog.md`

## Release notes

- Proposed release note sentence:
  - N/A (test harness only)
- Changelog type:
  - [ ] `feat`
  - [ ] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-playbook syntax-check on new `side_effect.yml`
- [x] Molecule `molecule test -s ubuntu` locally (Vagrant + provider)
- [x] README / docs updated

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit