### PR TITLE
ci: add scheduled and label-triggered AWS remote tests

### DIFF
--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -3,7 +3,7 @@ name: "CI — Pi-hole: AWS EC2 (remote tests)"
 
 on:
   schedule:
-    # Weekly smoke on master: amd64, pihole-unbound, include update-pihole.
+    # Bi-weekly smoke on master (every other Sunday 06:00 UTC; see schedule-gate).
     - cron: "0 6 * * 0"
   pull_request:
     types: [labeled, synchronize, reopened]
@@ -52,15 +52,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  schedule-gate:
+    name: Bi-weekly schedule gate
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Run on alternating ISO weeks only
+        id: check
+        run: |
+          week=$((10#$(date -u +%V)))
+          if [ $((week % 2)) -eq 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Bi-weekly on week: ${week}"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping off week (ISO week ${week})"
+          fi
+
   prepare-matrix:
     name: Prepare EC2 matrix
+    needs: schedule-gate
     runs-on: ubuntu-24.04
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
+      always() &&
       (
-        github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'run-aws-tests')
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'schedule' &&
+          github.ref == 'refs/heads/master' &&
+          needs.schedule-gate.outputs.run == 'true'
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          contains(github.event.pull_request.labels.*.name, 'run-aws-tests')
+        )
       )
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}

--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -3,8 +3,8 @@ name: "CI — Pi-hole: AWS EC2 (remote tests)"
 
 on:
   schedule:
-    # Bi-weekly smoke on master (every other Sunday 06:00 UTC; see schedule-gate).
-    - cron: "0 6 * * 0"
+    # Twice monthly on master: 1st and 15th at 06:00 UTC.
+    - cron: "0 6 1,15 * *"
   pull_request:
     types: [labeled, synchronize, reopened]
   workflow_dispatch:
@@ -52,42 +52,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  schedule-gate:
-    name: Bi-weekly schedule gate
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-24.04
-    outputs:
-      run: ${{ steps.check.outputs.run }}
-    steps:
-      - name: Run on alternating ISO weeks only
-        id: check
-        run: |
-          week=$((10#$(date -u +%V)))
-          if [ $((week % 2)) -eq 0 ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "Bi-weekly on week: ${week}"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping off week (ISO week ${week})"
-          fi
-
   prepare-matrix:
     name: Prepare EC2 matrix
-    needs: schedule-gate
     runs-on: ubuntu-24.04
     if: >-
-      always() &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
       (
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event_name == 'schedule' &&
-          github.ref == 'refs/heads/master' &&
-          needs.schedule-gate.outputs.run == 'true'
-        ) ||
-        (
-          github.event_name == 'pull_request' &&
-          contains(github.event.pull_request.labels.*.name, 'run-aws-tests')
-        )
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'run-aws-tests')
       )
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}

--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -1,7 +1,12 @@
 ---
-name: "CI — Pi-hole: AWS EC2 (manual)"
+name: "CI — Pi-hole: AWS EC2 (remote tests)"
 
 on:
+  schedule:
+    # Weekly smoke on master: amd64, pihole-unbound, include update-pihole.
+    - cron: "0 6 * * 0"
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
     inputs:
       scenario:
@@ -43,13 +48,20 @@ permissions:
   id-token: write
 
 concurrency:
-  group: aws-remote-tests-${{ github.workflow }}
+  group: aws-remote-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   prepare-matrix:
-    name: Prepare manual EC2 matrix
+    name: Prepare EC2 matrix
     runs-on: ubuntu-24.04
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/master') ||
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'run-aws-tests')
+      )
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       scenario: ${{ steps.matrix.outputs.scenario }}
@@ -59,6 +71,7 @@ jobs:
       - name: Resolve matrix
         id: matrix
         env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
           INPUT_PLATFORM_COVERAGE: ${{ github.event.inputs.platform_coverage }}
           INPUT_ARCH: ${{ github.event.inputs.arch }}
           INPUT_SCENARIO: ${{ github.event.inputs.scenario }}
@@ -70,10 +83,21 @@ jobs:
           import json
           import os
 
+          event = (os.environ.get("GITHUB_EVENT_NAME") or "").strip()
           profile = (os.environ.get("INPUT_PLATFORM_COVERAGE") or "one-arch").strip()
           scenario = (os.environ.get("INPUT_SCENARIO") or "pihole-unbound").strip()
           skip_update = (os.environ.get("INPUT_SKIP_UPDATE") or "false").strip().lower()
-          if profile in ("all-archs", "full"):
+
+          if event in ("schedule", "pull_request"):
+              profile = "one-arch"
+              scenario = "pihole-unbound"
+              skip_update = "false"
+              matrix = [{
+                  "os_family": "ubuntu",
+                  "os_version": "26.04",
+                  "arch": "amd64",
+              }]
+          elif profile in ("all-archs", "full"):
               matrix = [
                   {"os_family": "ubuntu", "os_version": "26.04", "arch": "amd64"},
                   {"os_family": "ubuntu", "os_version": "26.04", "arch": "arm64"},
@@ -158,6 +182,8 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v4

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ AWS EC2 workflows use ephemeral hosts and lifecycle hooks wired into
 `tests/remote/run.sh`:
 
 - `.github/workflows/rc-aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (RC)** (`v*-rc*`, Ubuntu 26.04)
-- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (remote tests)** (weekly on `master`, PR label `run-aws-tests`, or `workflow_dispatch`)
+- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (remote tests)** (bi-weekly on `master`, PR label `run-aws-tests`, or `workflow_dispatch`)
 - `.github/workflows/pihole-image-watch.yml` — daily check for new `pihole/pihole` Docker tags (GitHub issue alert)
 
 Infrastructure (VPC subnet, OIDC role, SSH key pair) is provisioned in the

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ AWS EC2 workflows use ephemeral hosts and lifecycle hooks wired into
 `tests/remote/run.sh`:
 
 - `.github/workflows/rc-aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (RC)** (`v*-rc*`, Ubuntu 26.04)
-- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (manual)** (`workflow_dispatch`)
+- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (remote tests)** (weekly on `master`, PR label `run-aws-tests`, or `workflow_dispatch`)
 - `.github/workflows/pihole-image-watch.yml` — daily check for new `pihole/pihole` Docker tags (GitHub issue alert)
 
 Infrastructure (VPC subnet, OIDC role, SSH key pair) is provisioned in the

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ AWS EC2 workflows use ephemeral hosts and lifecycle hooks wired into
 `tests/remote/run.sh`:
 
 - `.github/workflows/rc-aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (RC)** (`v*-rc*`, Ubuntu 26.04)
-- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (remote tests)** (bi-weekly on `master`, PR label `run-aws-tests`, or `workflow_dispatch`)
+- `.github/workflows/aws-remote-tests.yml` — **CI — Pi-hole: AWS EC2 (remote tests)** (1st and 15th monthly on `master`, PR label `run-aws-tests`, or `workflow_dispatch`)
 - `.github/workflows/pihole-image-watch.yml` — daily check for new `pihole/pihole` Docker tags (GitHub issue alert)
 
 Infrastructure (VPC subnet, OIDC role, SSH key pair) is provisioned in the

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -7,7 +7,7 @@ There are **two related workflows**. They share the same scripts and AWS setup; 
 | | **CI — Pi-hole: AWS EC2 (RC)** | **CI — Pi-hole: AWS EC2 (remote tests)** |
 |---|---|---|
 | File | `.github/workflows/rc-aws-remote-tests.yml` | `.github/workflows/aws-remote-tests.yml` |
-| Triggers | RC tags (`v1.0.0-rc.1`) or manual | Weekly on `master`, PR label `run-aws-tests`, or manual |
+| Triggers | RC tags (`v1.0.0-rc.1`) or manual | Bi-weekly on `master`, PR label `run-aws-tests`, or manual |
 | OS | Ubuntu 26.04 amd64 only | Scheduled/label: Ubuntu 26.04 amd64; manual: one or all archs |
 | Purpose | Pre-release gate on every RC tag | Scheduled smoke + on-demand operator / PR testing |
 
@@ -45,14 +45,18 @@ sequenceDiagram
 
 ```yaml
 schedule:
-  - cron: "0 6 * * 0"   # Weekly Sunday 06:00 UTC on master
+  - cron: "0 6 * * 0"   # Every other Sunday 06:00 UTC on master (ISO week gate)
 pull_request:
   types: [labeled, synchronize, reopened]   # when label run-aws-tests is present
 workflow_dispatch:   # Full manual matrix from GitHub UI
 ```
 
-**Automatic profile** (schedule + labeled PRs): Ubuntu 26.04 **amd64**,
+**Automatic profile** (bi-weekly schedule + labeled PRs): Ubuntu 26.04 **amd64**,
 `pihole-unbound`, **includes** `update-pihole.yaml` (does not pass `--skip-update`).
+
+Scheduled runs fire every **other** Sunday (06:00 UTC): the workflow cron still
+evaluates weekly, but job `schedule-gate` skips odd ISO weeks so EC2 cost stays
+bi-weekly.
 
 **PR label:** add `run-aws-tests` to a pull request to run the same profile against
 the PR head commit. Re-runs on new pushes while the label remains.
@@ -220,7 +224,7 @@ Three layers:
 2. **AWS build-ci** — disposable compute per run (create/destroy scripts)
 3. **Ansible** — the actual Pi-hole test (same playbooks used on real hardware)
 
-The remote-tests workflow covers **scheduled smoke on `master`**, **PR label
+The remote-tests workflow covers **bi-weekly smoke on `master`**, **PR label
 `run-aws-tests`**, and **on-demand operator testing**. The RC workflow is the
 **release gate** (tag-triggered, single fixed config). New upstream Pi-hole Docker
 tags are tracked by **`pihole-image-watch.yml`** (daily issue alert, no EC2 cost).

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -7,7 +7,7 @@ There are **two related workflows**. They share the same scripts and AWS setup; 
 | | **CI — Pi-hole: AWS EC2 (RC)** | **CI — Pi-hole: AWS EC2 (remote tests)** |
 |---|---|---|
 | File | `.github/workflows/rc-aws-remote-tests.yml` | `.github/workflows/aws-remote-tests.yml` |
-| Triggers | RC tags (`v1.0.0-rc.1`) or manual | Bi-weekly on `master`, PR label `run-aws-tests`, or manual |
+| Triggers | RC tags (`v1.0.0-rc.1`) or manual | Twice monthly on `master`, PR label `run-aws-tests`, or manual |
 | OS | Ubuntu 26.04 amd64 only | Scheduled/label: Ubuntu 26.04 amd64; manual: one or all archs |
 | Purpose | Pre-release gate on every RC tag | Scheduled smoke + on-demand operator / PR testing |
 
@@ -45,18 +45,16 @@ sequenceDiagram
 
 ```yaml
 schedule:
-  - cron: "0 6 * * 0"   # Every other Sunday 06:00 UTC on master (ISO week gate)
+  - cron: "0 6 1,15 * *"   # 1st and 15th of each month at 06:00 UTC on master
 pull_request:
   types: [labeled, synchronize, reopened]   # when label run-aws-tests is present
 workflow_dispatch:   # Full manual matrix from GitHub UI
 ```
 
-**Automatic profile** (bi-weekly schedule + labeled PRs): Ubuntu 26.04 **amd64**,
+**Automatic profile** (scheduled + labeled PRs): Ubuntu 26.04 **amd64**,
 `pihole-unbound`, **includes** `update-pihole.yaml` (does not pass `--skip-update`).
 
-Scheduled runs fire every **other** Sunday (06:00 UTC): the workflow cron still
-evaluates weekly, but job `schedule-gate` skips odd ISO weeks so EC2 cost stays
-bi-weekly.
+Scheduled runs fire on the **1st and 15th** of each month at 06:00 UTC.
 
 **PR label:** add `run-aws-tests` to a pull request to run the same profile against
 the PR head commit. Re-runs on new pushes while the label remains.
@@ -224,7 +222,7 @@ Three layers:
 2. **AWS build-ci** — disposable compute per run (create/destroy scripts)
 3. **Ansible** — the actual Pi-hole test (same playbooks used on real hardware)
 
-The remote-tests workflow covers **bi-weekly smoke on `master`**, **PR label
+The remote-tests workflow covers **twice-monthly smoke on `master`**, **PR label
 `run-aws-tests`**, and **on-demand operator testing**. The RC workflow is the
 **release gate** (tag-triggered, single fixed config). New upstream Pi-hole Docker
 tags are tracked by **`pihole-image-watch.yml`** (daily issue alert, no EC2 cost).

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -4,12 +4,12 @@ This document explains how the GitHub Actions AWS remote test workflows operate,
 
 There are **two related workflows**. They share the same scripts and AWS setup; they differ mainly in **when they run** and **how much they test**.
 
-| | **CI — Pi-hole: AWS EC2 (RC)** | **CI — Pi-hole: AWS EC2 (manual)** |
+| | **CI — Pi-hole: AWS EC2 (RC)** | **CI — Pi-hole: AWS EC2 (remote tests)** |
 |---|---|---|
 | File | `.github/workflows/rc-aws-remote-tests.yml` | `.github/workflows/aws-remote-tests.yml` |
-| Triggers | RC tags (`v1.0.0-rc.1`) or manual | Manual `workflow_dispatch` only |
-| OS | Ubuntu 26.04 amd64 only | Ubuntu 26.04 — one arch or amd64 + arm64 |
-| Purpose | Pre-release gate on every RC tag | Ad-hoc operator testing on demand |
+| Triggers | RC tags (`v1.0.0-rc.1`) or manual | Weekly on `master`, PR label `run-aws-tests`, or manual |
+| OS | Ubuntu 26.04 amd64 only | Scheduled/label: Ubuntu 26.04 amd64; manual: one or all archs |
+| Purpose | Pre-release gate on every RC tag | Scheduled smoke + on-demand operator / PR testing |
 
 Both follow the same core pattern: **assume AWS role → launch EC2 → Ansible → always destroy**.
 
@@ -44,10 +44,20 @@ sequenceDiagram
 ### 1. Triggers (`on`)
 
 ```yaml
-workflow_dispatch:   # Run workflow from GitHub UI only
+schedule:
+  - cron: "0 6 * * 0"   # Weekly Sunday 06:00 UTC on master
+pull_request:
+  types: [labeled, synchronize, reopened]   # when label run-aws-tests is present
+workflow_dispatch:   # Full manual matrix from GitHub UI
 ```
 
-**Manual inputs:**
+**Automatic profile** (schedule + labeled PRs): Ubuntu 26.04 **amd64**,
+`pihole-unbound`, **includes** `update-pihole.yaml` (does not pass `--skip-update`).
+
+**PR label:** add `run-aws-tests` to a pull request to run the same profile against
+the PR head commit. Re-runs on new pushes while the label remains.
+
+**Manual inputs** (`workflow_dispatch` only):
 
 | Input | Purpose |
 |---|---|
@@ -210,4 +220,7 @@ Three layers:
 2. **AWS build-ci** — disposable compute per run (create/destroy scripts)
 3. **Ansible** — the actual Pi-hole test (same playbooks used on real hardware)
 
-The manual workflow is for **on-demand operator testing**. The RC workflow is the **release gate** (tag-triggered, single fixed config). New upstream Pi-hole Docker tags are tracked by **`pihole-image-watch.yml`** (daily issue alert, no EC2 cost).
+The remote-tests workflow covers **scheduled smoke on `master`**, **PR label
+`run-aws-tests`**, and **on-demand operator testing**. The RC workflow is the
+**release gate** (tag-triggered, single fixed config). New upstream Pi-hole Docker
+tags are tracked by **`pihole-image-watch.yml`** (daily issue alert, no EC2 cost).

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -15,10 +15,10 @@ remote), but coverage is uneven on the riskiest path: rolling HA updates.
   - Suggested: add `side_effect.yml` to `molecule/ubuntu` importing
     `playbooks/update-pihole.yaml`, then extend HA verify post-update.
 
-- [ ] **Scheduled or label-triggered AWS remote tests**
-  - `aws-remote-tests.yml` is manual `workflow_dispatch` only.
-  - Options: nightly/weekly on `master`, or PR label `run-aws-tests`.
-  - Start with amd64-only, `pihole-unbound`, include update (not `--skip-update`).
+- [x] **Scheduled or label-triggered AWS remote tests** ([#155](https://github.com/steveyminecraft/ansible-pihole/issues/155))
+  - Runs on the **1st and 15th** of each month on `master`, or via PR label `run-aws-tests`.
+  - Profile: amd64-only, `pihole-unbound`, includes update (not `--skip-update`).
+  - Manual `workflow_dispatch` matrix unchanged.
 
 - [ ] **Check-mode for `update-pihole.yaml` in CI**
   - CI already runs check-mode for `ci-bootstrap.yaml`.
@@ -121,12 +121,12 @@ Local graphify setup is valuable; graph quality can be improved.
 |-------|------------|-----|
 | GitHub CI | Lint, syntax, check-mode bootstrap, compose validation | No functional HA or update path |
 | Molecule | 6 scenarios locally; HA verify on `ubuntu` | Not in CI; `update-pihole` in `ubuntu`, `ubuntu-26.04`, and `pihole-no-unbound` |
-| AWS remote | Bootstrap + optional `update-pihole` | Manual dispatch only |
+| AWS remote | Bootstrap + optional `update-pihole` | Scheduled 1st/15th + PR label; manual dispatch for full matrix |
 
 ## Suggested first issues
 
 1. `ubuntu` Molecule side_effect for `update-pihole` + post-update HA verify
-2. Scheduled AWS remote test on `master` (weekly, amd64)
+2. ~~Scheduled AWS remote test on `master` (twice monthly, amd64)~~ ([#155](https://github.com/steveyminecraft/ansible-pihole/issues/155))
 3. Runbook section for rolling updates / drain-resume
 4. Inventory pre-flight validator
 5. Upstream image check in CI

--- a/tests/remote/README.md
+++ b/tests/remote/README.md
@@ -100,5 +100,5 @@ variables:
 
 RC tag runs (`.github/workflows/rc-aws-remote-tests.yml`) use Ubuntu 26.04 only.
 The remote-tests workflow (`.github/workflows/aws-remote-tests.yml`) runs a
-weekly amd64 smoke on `master`, supports PR label `run-aws-tests`, and offers a
+bi-weekly amd64 smoke on `master`, supports PR label `run-aws-tests`, and offers a
 broader manual matrix when dispatched from the Actions UI.

--- a/tests/remote/README.md
+++ b/tests/remote/README.md
@@ -100,5 +100,5 @@ variables:
 
 RC tag runs (`.github/workflows/rc-aws-remote-tests.yml`) use Ubuntu 26.04 only.
 The remote-tests workflow (`.github/workflows/aws-remote-tests.yml`) runs a
-bi-weekly amd64 smoke on `master`, supports PR label `run-aws-tests`, and offers a
+twice-monthly amd64 smoke on `master` (1st and 15th), supports PR label `run-aws-tests`, and offers a
 broader manual matrix when dispatched from the Actions UI.

--- a/tests/remote/README.md
+++ b/tests/remote/README.md
@@ -99,5 +99,6 @@ variables:
 - `AWS_TEST_INSTANCE_TYPE_AMD64`
 
 RC tag runs (`.github/workflows/rc-aws-remote-tests.yml`) use Ubuntu 26.04 only.
-The manual workflow (`.github/workflows/aws-remote-tests.yml`) supports broader
-matrix profiles when needed.
+The remote-tests workflow (`.github/workflows/aws-remote-tests.yml`) runs a
+weekly amd64 smoke on `master`, supports PR label `run-aws-tests`, and offers a
+broader manual matrix when dispatched from the Actions UI.


### PR DESCRIPTION
Fixes #155

## Summary

- Twice-monthly cron (`0 6 1,15 * *`) on `master`: Ubuntu 26.04 amd64, `pihole-unbound`, includes `update-pihole`
- PR label `run-aws-tests` triggers the same profile against the PR head (re-runs on push while labeled)
- Manual `workflow_dispatch` with full input matrix unchanged
- Docs updated in `docs/aws-remote-tests-workflow.md`, README, `tests/remote/README.md`, and `docs/improvement-backlog.md`

## Release notes

- Proposed release note sentence:
  - N/A (CI automation only)
- Changelog type:
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] Workflow YAML parses cleanly
- [x] Standard CI (lint, syntax, security) green
- [x] AWS workflow correctly skips on PR without `run-aws-tests` label
- [ ] First scheduled run after merge (1st or 15th at 06:00 UTC)
- [ ] Optional: label a PR with `run-aws-tests` to confirm EC2 path (~90 min)

## Scope and risk

- Risk level: [ ] low  [x] medium  [ ] high
- Rollback plan: revert PR merge commit; disable schedule if EC2 cost/noise is an issue
- Note: requires existing AWS test repo variables/secrets (same as manual dispatch)