### PR TITLE
ci: add check-mode for update-pihole playbook in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
         run: |
           ansible-playbook -i inventory/ci/ci.yml playbooks/ci-bootstrap.yaml --check
 
+      - name: Check-mode update-pihole
+        run: |
+          ansible-playbook -i inventory/ci/ci.yml playbooks/update-pihole.yaml --check
+
       - name: Validate Pi-hole Compose modes
         run: ansible-playbook playbooks/ci-validate-pihole-modes.yaml
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ waits during test runs.
 | Layer | What runs | Where |
 |-------|-----------|--------|
 | **Unit** | Python checks for `scripts/default-container-images.py` (pinned images, Trivy matrix shape) | `tests/unit/`, PR-only job in `ci.yml` |
-| **Static / dry-run** | ansible-lint, yamllint, playbook `--syntax-check`, check-mode `ci-bootstrap` | `ci.yml` on every push/PR |
+| **Static / dry-run** | ansible-lint, yamllint, playbook `--syntax-check`, check-mode `ci-bootstrap` and `update-pihole` | `ci.yml` on every push/PR |
 | **Molecule integration** | Full bootstrap/update on Vagrant VMs | Local / self-hosted (`molecule/*`) |
 | **AWS integration** | Ephemeral EC2 → production playbooks → teardown | `rc-aws-remote-tests.yml`, `aws-remote-tests.yml` |
 

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -20,10 +20,9 @@ remote), but coverage is uneven on the riskiest path: rolling HA updates.
   - Profile: amd64-only, `pihole-unbound`, includes update (not `--skip-update`).
   - Manual `workflow_dispatch` matrix unchanged.
 
-- [ ] **Check-mode for `update-pihole.yaml` in CI**
+- [x] **Check-mode for `update-pihole.yaml` in CI** ([#157](https://github.com/steveyminecraft/ansible-pihole/issues/157))
   - CI already runs check-mode for `ci-bootstrap.yaml`.
-  - Add syntax + `--check` for `playbooks/update-pihole.yaml` against
-    `inventory/ci/ci.yml`.
+  - `inventory/ci/group_vars/all.yml` supplies CI-safe vars; live DNS/container steps skip in `--check`.
 
 - [ ] **Expand unit/integration tests beyond scripts**
   - Current unit tests: `default-container-images`, upstream image check, AWS
@@ -119,7 +118,7 @@ Local graphify setup is valuable; graph quality can be improved.
 
 | Layer | Runs today | Gap |
 |-------|------------|-----|
-| GitHub CI | Lint, syntax, check-mode bootstrap, compose validation | No functional HA or update path |
+| GitHub CI | Lint, syntax, check-mode bootstrap + update-pihole, compose validation | No functional HA or update path |
 | Molecule | 6 scenarios locally; HA verify on `ubuntu` | Not in CI; `update-pihole` in `ubuntu`, `ubuntu-26.04`, and `pihole-no-unbound` |
 | AWS remote | Bootstrap + optional `update-pihole` | Scheduled 1st/15th + PR label; manual dispatch for full matrix |
 

--- a/inventory/ci/group_vars/all.yml
+++ b/inventory/ci/group_vars/all.yml
@@ -1,0 +1,12 @@
+---
+# Shared CI inventory vars for localhost dry-runs (check-mode, syntax-check).
+# Not used in production — keeps Pi-hole/HA playbooks from failing on missing vault data.
+pihole_ha_mode: false
+pihole_compose_dir: /opt/pihole
+pihole_image: "pihole/pihole:2026.07.2"
+pihole_environment_variables:
+  TZ: Etc/UTC
+  FTLCONF_webserver_api_password: ci-check-mode-secret
+  FTLCONF_dns_listeningMode: ALL
+  DHCP_ACTIVE: false
+  REV_SERVER: false

--- a/playbooks/update-pihole.yaml
+++ b/playbooks/update-pihole.yaml
@@ -14,9 +14,11 @@
       tags: [updates, system]
     - role: steveyminecraft.pihole.pihole
       tags: [pihole, dns]
+      when: not ansible_check_mode
   post_tasks:
     - name: Validate node DNS before resuming keepalived
       tags: [pihole, dns, ha]
+      when: not ansible_check_mode
       block:
         - name: Wait for local Pi-hole DNS listener
           ansible.builtin.wait_for:


### PR DESCRIPTION
Fixes #157

## Summary

- Add `inventory/ci/group_vars/all.yml` with CI-safe defaults (HA off, valid Pi-hole password, compose paths)
- Run `ansible-playbook -i inventory/ci/ci.yml playbooks/update-pihole.yaml --check` in the CI ansible-tests job
- Skip Pi-hole deploy and live DNS health gates in `update-pihole.yaml` when `ansible_check_mode` (same pattern as `ci-bootstrap.yaml`)
- Update README testing table and improvement backlog

## Release notes

- Proposed release note sentence:
  - N/A (CI only)
- Changelog type:
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] `ansible-playbook -i inventory/ci/ci.yml playbooks/update-pihole.yaml --check` passes locally
- [x] `--syntax-check` passes
- [ ] CI ansible-tests matrix green

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit
- Production behavior unchanged: check-mode guards only affect `--check` runs


Made with [Cursor](https://cursor.com)