### PR TITLE
test: add update-pihole health gate and HA playbook unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,5 +194,6 @@ jobs:
 
       - name: Run Python unit tests (container image matrix)
         run: |
+          python -m pip install --upgrade jinja2
           python -m unittest discover -s tests/unit -p 'test_*.py'
           python scripts/validate-secure-defaults.py

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ waits during test runs.
 
 | Layer | What runs | Where |
 |-------|-----------|--------|
-| **Unit** | Python checks for `scripts/default-container-images.py` (pinned images, Trivy matrix shape) | `tests/unit/`, PR-only job in `ci.yml` |
+| **Unit** | Python checks for scripts (`default-container-images`, upstream image watch, AWS cleanup, update-pihole health gates) and HA playbook/Compose contracts | `tests/unit/`, PR-only job in `ci.yml` |
 | **Static / dry-run** | ansible-lint, yamllint, playbook `--syntax-check`, check-mode `ci-bootstrap` and `update-pihole` | `ci.yml` on every push/PR |
 | **Molecule integration** | Full bootstrap/update on Vagrant VMs | Local / self-hosted (`molecule/*`) |
 | **AWS integration** | Ephemeral EC2 → production playbooks → teardown | `rc-aws-remote-tests.yml`, `aws-remote-tests.yml` |

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -24,13 +24,10 @@ remote), but coverage is uneven on the riskiest path: rolling HA updates.
   - CI already runs check-mode for `ci-bootstrap.yaml`.
   - `inventory/ci/group_vars/all.yml` supplies CI-safe vars; live DNS/container steps skip in `--check`.
 
-- [ ] **Expand unit/integration tests beyond scripts**
-  - Current unit tests: `default-container-images`, upstream image check, AWS
-    cleanup scripts.
-  - Gaps: playbook health-gate logic, rolling serial behavior, rendered
-    templates.
-  - Consider lightweight `ansible-test` or expression-level tests for
-    `failed_when` blocks in `update-pihole.yaml`.
+- [x] **Expand unit/integration tests beyond scripts** ([#159](https://github.com/steveyminecraft/ansible-pihole/issues/159))
+  - Added `scripts/update-pihole-health.py` plus unit tests for dig health-gate logic.
+  - Playbook contract tests cover rolling `serial: 1`, check-mode guards, VIP retry, Molecule update path.
+  - Compose template smoke tests cover DHCP port gating.
 
 ## Priority 2 — Operations documentation
 

--- a/scripts/update-pihole-health.py
+++ b/scripts/update-pihole-health.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""DNS health-gate helpers mirroring playbooks/update-pihole.yaml expressions."""
+
+from __future__ import annotations
+
+import re
+
+# Keep aligned with failed_when / until filters in playbooks/update-pihole.yaml.
+IPV4_LINE_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def dig_stdout_has_ipv4_answer(stdout_lines: list[str] | tuple[str, ...] | None) -> bool:
+    """Return True when dig +short output contains at least one IPv4 A-record line."""
+    if not stdout_lines:
+        return False
+    return any(IPV4_LINE_PATTERN.match(line.strip()) for line in stdout_lines)

--- a/tests/unit/test_update_pihole_health.py
+++ b/tests/unit/test_update_pihole_health.py
@@ -1,0 +1,54 @@
+"""Unit tests for scripts/update-pihole-health.py (update-pihole DNS health gates)."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "update-pihole-health.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("update_pihole_health", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class UpdatePiholeHealthGateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.helper = load_module()
+
+    def test_accepts_single_ipv4_line(self) -> None:
+        self.assertTrue(self.helper.dig_stdout_has_ipv4_answer(["104.16.132.229"]))
+
+    def test_accepts_ipv4_among_blank_lines(self) -> None:
+        self.assertTrue(
+            self.helper.dig_stdout_has_ipv4_answer(["", "104.16.132.229", ""])
+        )
+
+    def test_rejects_empty_output(self) -> None:
+        self.assertFalse(self.helper.dig_stdout_has_ipv4_answer([]))
+        self.assertFalse(self.helper.dig_stdout_has_ipv4_answer(None))
+
+    def test_rejects_dig_errors_and_cnames(self) -> None:
+        self.assertFalse(
+            self.helper.dig_stdout_has_ipv4_answer(
+                [";; connection timed out; no servers could be reached"]
+            )
+        )
+        self.assertFalse(self.helper.dig_stdout_has_ipv4_answer(["cloudflare.com."]))
+
+    def test_rejects_ipv6_only_answers(self) -> None:
+        self.assertFalse(
+            self.helper.dig_stdout_has_ipv4_answer(["2606:4700:4700::1111"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_update_pihole_playbook.py
+++ b/tests/unit/test_update_pihole_playbook.py
@@ -1,0 +1,114 @@
+"""Playbook contract and template tests for rolling HA update paths."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATE_PIHOLE = ROOT / "playbooks" / "update-pihole.yaml"
+ROLLING_PLAYBOOKS = (
+    ROOT / "playbooks" / "update-pihole.yaml",
+    ROOT / "playbooks" / "bootstrap-pihole.yaml",
+    ROOT / "playbooks" / "keepalived.yaml",
+)
+UBUNTU_MOLECULE = ROOT / "molecule" / "ubuntu" / "molecule.yml"
+COMPOSE_TEMPLATE = ROOT / "roles" / "pihole" / "templates" / "docker-compose.yml.j2"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+class RollingHaPlaybookContractTests(unittest.TestCase):
+    def test_rolling_ha_playbooks_use_serial_one(self) -> None:
+        for path in ROLLING_PLAYBOOKS:
+            with self.subTest(playbook=path.name):
+                doc = load_yaml(path)
+                self.assertEqual(doc[0].get("serial"), 1)
+
+    def test_update_pihole_playbook_ha_safety_flags(self) -> None:
+        first_play = load_yaml(UPDATE_PIHOLE)[0]
+        self.assertTrue(first_play.get("any_errors_fatal"))
+
+        pihole_role = next(
+            role for role in first_play["roles"] if role["role"].endswith(".pihole")
+        )
+        self.assertEqual(pihole_role.get("when"), "not ansible_check_mode")
+
+        post_task = first_play["post_tasks"][0]
+        self.assertEqual(post_task.get("when"), "not ansible_check_mode")
+        self.assertIn("rescue", post_task)
+        self.assertIn("block", post_task)
+
+    def test_update_pihole_vip_verify_retries_until_ipv4(self) -> None:
+        vip_task = load_yaml(UPDATE_PIHOLE)[1]["tasks"][0]
+        self.assertEqual(vip_task.get("retries"), 30)
+        self.assertEqual(vip_task.get("delay"), 2)
+        self.assertIn("until", vip_task)
+        self.assertIn("pihole_ha_mode", str(vip_task.get("when")))
+
+    def test_ubuntu_molecule_exercises_update_side_effect(self) -> None:
+        sequence = load_yaml(UBUNTU_MOLECULE)["scenario"]["test_sequence"]
+        side_effect_index = sequence.index("side_effect")
+        verify_indices = [index for index, step in enumerate(sequence) if step == "verify"]
+        self.assertGreater(side_effect_index, verify_indices[0])
+        self.assertLess(side_effect_index, verify_indices[-1])
+
+
+class PiholeComposeTemplateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        loader = FileSystemLoader(COMPOSE_TEMPLATE.parent)
+        env = Environment(loader=loader, undefined=StrictUndefined)
+        env.filters["bool"] = lambda value: (
+            value if isinstance(value, bool) else str(value).lower() in ("true", "1", "yes")
+        )
+        env.filters["string"] = str
+        cls.env = env
+
+    def _render(self, **overrides) -> str:
+        variables = {
+            "pihole_container_name": "pihole",
+            "inventory_hostname": "node1",
+            "pihole_image": "pihole/pihole:2026.07.2",
+            "pihole_use_host_network": False,
+            "pihole_enable_unbound": True,
+            "pihole_network_name": "dns_net",
+            "pihole_dir_loc": "/opt/pihole",
+            "pihole_environment_variables": {
+                "TZ": "UTC",
+                "DHCP_ACTIVE": False,
+                "FTLCONF_dns_listeningMode": "ALL",
+            },
+            "pihole_container_cap_add": ["NET_ADMIN"],
+            "pihole_rocky_network_debug": False,
+            "pihole_docker_dns": [],
+            "pihole_webport_http": "80",
+            "pihole_webport_https": "443",
+        }
+        variables.update(overrides)
+        template = self.env.get_template(COMPOSE_TEMPLATE.name)
+        return template.render(**variables)
+
+    def test_dhcp_disabled_omits_dhcp_port(self) -> None:
+        rendered = self._render()
+        self.assertNotIn("67:67/udp", rendered)
+
+    def test_dhcp_enabled_publishes_dhcp_port(self) -> None:
+        rendered = self._render(
+            pihole_environment_variables={
+                "TZ": "UTC",
+                "DHCP_ACTIVE": True,
+                "FTLCONF_dns_listeningMode": "ALL",
+            }
+        )
+        self.assertIn("67:67/udp", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #159

## Summary

- Add `scripts/update-pihole-health.py` mirroring IPv4 dig health-gate logic from `playbooks/update-pihole.yaml`
- Add unit tests for pass/fail dig outputs, rolling HA `serial: 1` contract, check-mode/rescue/VIP retry structure, and Molecule update sequence
- Add Compose template smoke tests (DHCP port gating) with Ansible-compatible Jinja filters
- Install `jinja2` in CI unit-test step; update README and improvement backlog

## Release notes

- Proposed release note sentence:
  - N/A (test harness only)
- Changelog type:
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] `python -m unittest discover -s tests/unit` passes locally (21 tests)
- [ ] CI policy & script validation job green

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit


Made with [Cursor](https://cursor.com)