### PR TITLE
docs: expand stub role READMEs for HA drain/resume and Nebula Sync

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -37,9 +37,9 @@ Docs are clear at a high level but thin relative to playbook complexity.
   - Cover: local DNS wait, Unbound check, VIP verify, keepalived resume.
   - Include: what fails, expected timing, retry guidance.
 
-- [ ] **Expand stub role READMEs**
-  - Thin today: `start_keepalived`, `stop_keepalived`, `sshd`, `nebula_sync`.
-  - Document drain/resume pattern, when each role runs, relevant tags.
+- [x] **Expand stub role READMEs** ([#163](https://github.com/steveyminecraft/ansible-pihole/issues/163))
+  - Documented `start_keepalived`, `stop_keepalived`, `sshd`, `nebula_sync`.
+  - Cover drain/resume pattern, when each role runs, relevant tags.
 
 - [ ] **Cross-link production change runbooks**
   - Chain: `upgrade-runbook.md` → `failover-testing.md` →

--- a/roles/nebula_sync/README.md
+++ b/roles/nebula_sync/README.md
@@ -1,5 +1,55 @@
 # nebula_sync
 
-Deploy Nebula Sync to replicate Pi-hole configuration between HA nodes.
+Deploy the [Nebula Sync](https://github.com/lovelaze/nebula-sync) container on
+the HA **controller** host to replicate Pi-hole settings to replica nodes.
+
+This role is separate from the keepalived drain/resume path. It runs after both
+nodes are bootstrapped and answers DNS.
+
+## When it runs
+
+| Playbook | Hosts | Tags |
+|----------|-------|------|
+| `playbooks/sync.yaml` | `nebula_sync_controller` (exactly one host in inventory) | `nebulasync`, `nebula`, `sync` |
+
+`bootstrap-pihole.yaml` and `update-pihole.yaml` do **not** invoke this role.
+Run `sync.yaml` when you need to (re)deploy or migrate the Nebula Sync controller.
+
+## Requirements
+
+Define in inventory/vault (non-placeholder values):
+
+- `nebula_sync_primary_url` and `nebula_sync_primary_password`
+- `nebula_sync_replicas` — list of `{ url, password }` entries for replica
+  Pi-hole API endpoints
+
+Optional tuning lives in `defaults/main.yml` (`nebula_sync_cron`, sync toggles,
+image tag, secret-file layout).
+
+By default the role:
+
+- Renders Compose under `nebula_sync_dir` (default `/opt/nebula-sync`)
+- Stores credentials in read-only secret files mounted into the container
+- Recreates the container when config changes or legacy plaintext env is detected
+
+Replica hosts do not run this container — Molecule and remote verify playbooks
+assert the sync container is absent on replicas.
+
+## Example
+
+Deploy or refresh Nebula Sync on the controller:
+
+```bash
+ansible-playbook -i inventory.yml playbooks/sync.yaml
+```
+
+Tag-scoped run:
+
+```bash
+ansible-playbook -i inventory.yml playbooks/sync.yaml --tags nebulasync
+```
+
+After bootstrap or restore, confirm replication with the checks in
+[Backup and restore](../../docs/backup-and-restore.md#post-restore-checks).
 
 Part of the `steveyminecraft.pihole` collection.

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -1,5 +1,36 @@
 # sshd
 
-Harden and configure OpenSSH server settings on Pi-hole hosts.
+Apply baseline OpenSSH server hardening on Pi-hole hosts.
+
+## When it runs
+
+| Playbook | Position | Tags |
+|----------|----------|------|
+| `playbooks/bootstrap-pihole.yaml` | After `bootstrap` and `updates`, before `keepalived` | `sshd`, `system` |
+
+This role is part of **initial bootstrap**, not the rolling update path.
+`playbooks/update-pihole.yaml` does not include it.
+
+## What it changes
+
+- Creates `/run/sshd` on Debian-family hosts when needed
+- Sets in `/etc/ssh/sshd_config`:
+  - `PermitRootLogin no`
+  - `PasswordAuthentication no`
+  - `MaxSessions 5`
+  - `MaxAuthTries 3`
+- Validates the config with `sshd -T` before applying each line
+- Restarts SSH via `Restart_SSH` (Debian) or `Restart_SSHD` (RedHat)
+
+Ensure key-based access works before running bootstrap on a new host. The role
+does not manage authorized keys — the `bootstrap` role handles SSH keys.
+
+## Example
+
+Bootstrap only SSH-related tasks on lab hosts:
+
+```bash
+ansible-playbook -i inventory.yml playbooks/bootstrap-pihole.yaml --tags sshd
+```
 
 Part of the `steveyminecraft.pihole` collection.

--- a/roles/start_keepalived/README.md
+++ b/roles/start_keepalived/README.md
@@ -1,5 +1,47 @@
 # start_keepalived
 
-Start keepalived after maintenance or Pi-hole updates.
+Start the keepalived (or legacy `keepalive`) service after maintenance once the
+node passes local DNS health checks.
+
+This role is the **resume** half of the HA maintenance pattern. It does not
+configure keepalived — use the `keepalived` role for that.
+
+## When it runs
+
+| Playbook | Position | Tags |
+|----------|----------|------|
+| `playbooks/bootstrap-pihole.yaml` | Included in post-tasks after local DNS/Unbound validation | (inherits `pihole`, `dns`, `ha` from the block) |
+| `playbooks/update-pihole.yaml` | Included in post-tasks after local DNS/Unbound validation | (inherits `pihole`, `dns`, `ha` from the block) |
+
+The role is **not** listed in the main `roles:` section. Playbooks call it with
+`include_role` only after:
+
+- `wait_for` on `127.0.0.1:53` succeeds, and
+- `dig +short @127.0.0.1 <health-qname>` returns an IPv4 answer, and
+- optional Unbound `dig` from inside the Pi-hole container passes when Unbound is
+  deployed.
+
+If validation fails, the rescue block stops the play and this role does not run,
+leaving the node drained until you repair it and re-run the playbook.
+
+## Drain/resume pattern
+
+Pair with `stop_keepalived` at the start of the same playbook run:
+
+1. `stop_keepalived` — release the VIP from this node
+2. Package/Pi-hole changes
+3. Local DNS gates
+4. **`start_keepalived`** — return the node to VIP candidacy
+
+See [Upgrade runbook](../../docs/upgrade-runbook.md#health-gates) for timing and
+retry details.
+
+## Example
+
+Re-run rolling update after fixing a drained node:
+
+```bash
+ansible-playbook -i inventory.yml playbooks/update-pihole.yaml --limit node2
+```
 
 Part of the `steveyminecraft.pihole` collection.

--- a/roles/stop_keepalived/README.md
+++ b/roles/stop_keepalived/README.md
@@ -1,5 +1,46 @@
 # stop_keepalived
 
-Stop keepalived before maintenance or Pi-hole updates.
+Stop the keepalived (or legacy `keepalive`) service before maintenance so the VIP
+can move to another node.
+
+This role is the **drain** half of the HA maintenance pattern. It does not
+configure keepalived — use the `keepalived` role for that.
+
+## When it runs
+
+| Playbook | Position | Tags |
+|----------|----------|------|
+| `playbooks/bootstrap-pihole.yaml` | First role on each host (`serial: 1`) | `stopkeepalived`, `drain`, `ha` |
+| `playbooks/update-pihole.yaml` | First role on each host (`serial: 1`) | `stopkeepalived`, `drain`, `ha` |
+
+The role gathers service facts, detects `keepalived.service` or the Ubuntu typo
+`keepalive.service`, and stops the unit when present. If keepalived is not
+installed, the role is a no-op.
+
+## Drain/resume pattern
+
+1. **Drain** — this role stops keepalived on the current node.
+2. **Change** — bootstrap, updates, or Pi-hole role tasks run while the node is
+   out of VIP service.
+3. **Validate** — playbook post-tasks wait for local DNS and optional Unbound.
+4. **Resume** — `start_keepalived` runs only after validation passes.
+
+If DNS validation fails, keepalived is **not** restarted on that node. See
+[Upgrade runbook](../../docs/upgrade-runbook.md#health-gates) for failure and
+retry guidance.
+
+## Example (maintenance window)
+
+Drain and update one node only:
+
+```bash
+ansible-playbook -i inventory.yml playbooks/update-pihole.yaml --limit node1
+```
+
+Skip drain/resume helpers while testing non-HA changes:
+
+```bash
+ansible-playbook -i inventory.yml playbooks/update-pihole.yaml --skip-tags drain,ha
+```
 
 Part of the `steveyminecraft.pihole` collection.


### PR DESCRIPTION
Fixes #163

## Summary

- Expand READMEs for `stop_keepalived`, `start_keepalived`, `sshd`, and `nebula_sync`
- Document playbook entry points, tags, and the drain/resume pattern for keepalived helpers
- Mark P2 stub-README backlog item complete

## Release notes

- Proposed release note sentence:
  - N/A (documentation only)
- Changelog type:
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] Documentation-only diff reviewed
- [x] `graphify update .` run after docs change
- [ ] CI green

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit


Made with [Cursor](https://cursor.com)