### PR TITLE
ci: skip full matrix for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,47 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+      docs: ${{ steps.set.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Match changed paths
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+
+      - name: Set change flags
+        id: set
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "docs=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+            echo "docs=${{ steps.filter.outputs.docs }}" >> "$GITHUB_OUTPUT"
+          fi
+
   pr-title-check:
     name: PR title follows conventional commits
     runs-on: ubuntu-24.04
+    needs: changes
     steps:
       - name: Validate PR title
         if: github.event_name == 'pull_request'
@@ -41,10 +79,26 @@ jobs:
         if: github.event_name != 'pull_request'
         run: echo "PR title validation only runs on pull_request events."
 
+  docs-only:
+    name: Docs-only change (skip full matrix)
+    runs-on: ubuntu-24.04
+    needs: [changes, pr-title-check]
+    if: >-
+      needs.changes.outputs.docs == 'true' &&
+      needs.changes.outputs.code != 'true'
+    steps:
+      - name: Skip heavy CI for documentation-only diffs
+        run: |
+          echo "Documentation-only change detected."
+          echo "Skipping Ansible lint, syntax/dry-run matrix, and PR safety checks."
+
   lint:
     name: Ansible & YAML lint (${{ matrix.runner }} / Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.runner }}
-    needs: pr-title-check
+    needs: [changes, pr-title-check]
+    if: >-
+      needs.changes.outputs.code == 'true' ||
+      github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +143,14 @@ jobs:
   ansible-tests-ubuntu:
     name: Ansible syntax & dry-run (${{ matrix.runner }} / Python ${{ matrix.python-version }} / Core ${{ matrix.ansible-core }})
     runs-on: ${{ matrix.runner }}
-    needs: lint
+    needs: [changes, lint]
+    if: >-
+      always() &&
+      needs.lint.result == 'success' &&
+      (
+        needs.changes.outputs.code == 'true' ||
+        github.event_name == 'workflow_dispatch'
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -145,8 +206,10 @@ jobs:
   ci-safety-checks:
     name: Policy & script validation (PR)
     runs-on: ubuntu-24.04
-    needs: ansible-tests-ubuntu
-    if: github.event_name == 'pull_request'
+    needs: [changes, ansible-tests-ubuntu]
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -197,3 +260,47 @@ jobs:
           python -m pip install --upgrade jinja2
           python -m unittest discover -s tests/unit -p 'test_*.py'
           python scripts/validate-secure-defaults.py
+
+  ci-success:
+    name: CI checks complete
+    runs-on: ubuntu-24.04
+    needs:
+      - changes
+      - pr-title-check
+      - docs-only
+      - lint
+      - ansible-tests-ubuntu
+      - ci-safety-checks
+    if: always()
+    steps:
+      - name: Validate CI outcome for change set
+        env:
+          CODE: ${{ needs.changes.outputs.code }}
+          PR_TITLE: ${{ needs.pr-title-check.result }}
+          DOCS_ONLY: ${{ needs.docs-only.result }}
+          LINT: ${{ needs.lint.result }}
+          ANSIBLE: ${{ needs.ansible-tests-ubuntu.result }}
+          SAFETY: ${{ needs.ci-safety-checks.result }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$PR_TITLE" != "success" ]; then
+            echo "PR title check failed."
+            exit 1
+          fi
+          if [ "$CODE" = "true" ]; then
+            if [ "$LINT" != "success" ] || [ "$ANSIBLE" != "success" ]; then
+              echo "Full CI matrix did not succeed (lint=${LINT}, ansible=${ANSIBLE})."
+              exit 1
+            fi
+            if [ "$EVENT" = "pull_request" ] && [ "$SAFETY" != "success" ]; then
+              echo "PR safety checks did not succeed."
+              exit 1
+            fi
+          else
+            if [ "$DOCS_ONLY" != "success" ]; then
+              echo "Docs-only CI gate did not succeed."
+              exit 1
+            fi
+          fi
+          echo "CI checks complete."

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -18,9 +18,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Match changed paths
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+
+      - name: Set change flags
+        id: set
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  docs-only:
+    name: Docs-only change (skip Galaxy validation)
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.code != 'true'
+    steps:
+      - name: Skip collection validation for documentation-only diffs
+        run: echo "Documentation-only change; skipping Galaxy build/validate matrix."
+
   validate:
     name: Build and validate steveyminecraft.pihole (${{ matrix.ansible-core }})
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,9 +17,59 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      code: ${{ steps.set.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Match changed paths
+        id: filter
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          github.event_name != 'schedule'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+
+      - name: Set change flags
+        id: set
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch|schedule)
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "code=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  docs-only:
+    name: Docs-only change (skip security matrix)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code != 'true'
+    steps:
+      - name: Skip security scans for documentation-only diffs
+        run: echo "Documentation-only change; skipping CodeQL and Trivy jobs."
+
   codeql:
     name: CodeQL - GitHub Actions
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
 
     permissions:
       actions: read
@@ -42,6 +92,8 @@ jobs:
   trivy:
     name: Trivy filesystem scan
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
 
     permissions:
       contents: read
@@ -72,6 +124,8 @@ jobs:
   default-images:
     name: Resolve default container images
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     outputs:
       matrix: ${{ steps.images.outputs.matrix }}
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ waits during test runs.
 | Layer | What runs | Where |
 |-------|-----------|--------|
 | **Unit** | Python checks for scripts (`default-container-images`, upstream image watch, AWS cleanup, update-pihole health gates) and HA playbook/Compose contracts | `tests/unit/`, PR-only job in `ci.yml` |
-| **Static / dry-run** | ansible-lint, yamllint, playbook `--syntax-check`, check-mode `ci-bootstrap` and `update-pihole` | `ci.yml` on every push/PR |
+| **Static / dry-run** | ansible-lint, yamllint, playbook `--syntax-check`, check-mode `ci-bootstrap` and `update-pihole` | `ci.yml` on code changes (skipped for docs-only PRs) |
 | **Molecule integration** | Full bootstrap/update on Vagrant VMs | Local / self-hosted (`molecule/*`) |
 | **AWS integration** | Ephemeral EC2 → production playbooks → teardown | `rc-aws-remote-tests.yml`, `aws-remote-tests.yml` |
 
@@ -399,6 +399,10 @@ runs lint (ansible-lint, yamllint), installs dependencies via
 [`scripts/install-ansible-collections.sh`](scripts/install-ansible-collections.sh),
 and syntax-checks / check-modes selected playbooks against [`inventory/ci/`](inventory/ci/)
 on GitHub-hosted Ubuntu 24.04 x64 and ARM64 runners.
+
+Pull requests that touch only `docs/**` and `**/*.md` skip the heavy Ansible lint
+and test matrix. Those PRs still run the PR title check and a lightweight
+`CI checks complete` gate. Use `workflow_dispatch` to force a full run.
 
 Hosted CI also runs lightweight safety checks for Molecule configuration files (YAML/schema
 sanity) that do not require Vagrant or a VM provider. Full Molecule Vagrant scenarios remain


### PR DESCRIPTION
Fixes #165

## Summary

- Add path detection for docs-only diffs (`docs/**`, `**/*.md`)
- Skip heavy jobs in `ci.yml`, `security.yml`, and `galaxy-publish.yml` when no code paths changed
- Add `CI checks complete` aggregation job so docs-only PRs still have a green required gate
- Document behavior in README

## Release notes

- Proposed release note sentence:
  - N/A (CI optimization)
- Changelog type:
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] Workflow YAML parses locally
- [ ] Full CI on this PR (touches workflows — expected)
- [ ] Follow-up docs PR (#164) should show skipped matrix after merge

## Scope and risk

- Risk level: [ ] low  [x] medium  [ ] high
- Rollback plan: revert PR merge commit
- Note: if branch protection requires specific job names, switch required check to **CI checks complete**


Made with [Cursor](https://cursor.com)