### PR TITLE
docs: cross-link production change runbooks

### DIFF
--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -1,5 +1,9 @@
 # Backup and Restore
 
+For planned production changes, start with the
+[production change checklist](upgrade-runbook.md#production-change-checklist).
+This page covers its backup and recovery steps.
+
 ## What to back up
 
 - Pi-hole persistent data:
@@ -12,6 +16,17 @@
 1. Snapshot/export Pi-hole directories from both nodes.
 2. Store backups off-host.
 3. Keep retention policy (daily/weekly) appropriate for your environment.
+
+## Pre-change backup checklist
+
+- [ ] Back up `/opt/pihole/etc/pihole` and `/opt/pihole/etc/dnsmasq.d` from
+  both nodes.
+- [ ] Back up the production inventory and vaulted secrets without decrypting
+  secrets into the change record.
+- [ ] Store the backup off-host and record its location and timestamp.
+- [ ] Confirm the backup is readable before starting maintenance.
+- [ ] Continue with the
+  [rolling update steps](upgrade-runbook.md#steps).
 
 ## Restore (single node loss)
 
@@ -32,3 +47,7 @@
 - `dig +short @<vip-ip> <pihole_verify_qname>`
 - Keepalived service running on both nodes.
 - Nebula Sync containers running and pointed at expected endpoints.
+
+After recovery, complete the
+[manual failover checks](failover-testing.md#manual-production-checks) before
+closing the incident or change.

--- a/docs/failover-testing.md
+++ b/docs/failover-testing.md
@@ -2,6 +2,11 @@
 
 Use Molecule shared HA verification and manual checks to confirm failover behavior.
 
+For planned production changes, reach this page after backup and update through
+the [production change checklist](upgrade-runbook.md#production-change-checklist).
+After the checks below pass, return to that checklist for Nebula Sync
+verification and change recording.
+
 ## Automated (Molecule)
 
 Run:
@@ -42,3 +47,9 @@ The `ubuntu` and `ubuntu-26.04` scenarios run a full test sequence:
 
 3. Simulate primary outage (maintenance window) and confirm VIP moves to backup.
 4. Restore primary and confirm failback policy outcome.
+5. Return to the
+   [production change checklist](upgrade-runbook.md#production-change-checklist)
+   and verify Nebula Sync replication.
+
+If failover validation exposes data loss or a node cannot be recovered, follow
+[Backup and restore](backup-and-restore.md).

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -41,7 +41,7 @@ Docs are clear at a high level but thin relative to playbook complexity.
   - Documented `start_keepalived`, `stop_keepalived`, `sshd`, `nebula_sync`.
   - Cover drain/resume pattern, when each role runs, relevant tags.
 
-- [ ] **Cross-link production change runbooks**
+- [x] **Cross-link production change runbooks** ([#167](https://github.com/steveyminecraft/ansible-pihole/issues/167))
   - Chain: `upgrade-runbook.md` → `failover-testing.md` →
     `backup-and-restore.md` as a single checklist (backup → update → VIP →
     Nebula sync verify).

--- a/docs/upgrade-runbook.md
+++ b/docs/upgrade-runbook.md
@@ -4,6 +4,29 @@
 
 Upgrade packages and roles while keeping DNS service available through rolling updates.
 
+## Production change checklist
+
+Use this as the entry point for a planned production change. Complete the
+linked runbooks in order:
+
+- [ ] **Backup** — follow the
+  [pre-change backup checklist](backup-and-restore.md#pre-change-backup-checklist)
+  for both nodes, inventory, and vaulted secrets.
+- [ ] **Pre-check DNS** — query both nodes and the VIP as shown below.
+- [ ] **Rolling update** — run `playbooks/update-pihole.yaml` and confirm each
+  node passes its local DNS and optional Unbound health gates before keepalived
+  resumes.
+- [ ] **Node and VIP validation** — complete the
+  [manual production checks](failover-testing.md#manual-production-checks).
+- [ ] **Failover validation** — during the maintenance window, move the VIP to
+  the peer and restore it as described in
+  [Failover testing](failover-testing.md).
+- [ ] **Nebula Sync verification** — run `playbooks/sync.yaml`, confirm the
+  Nebula Sync container is running on the controller only, and verify a known
+  Pi-hole setting from the primary appears on the replica.
+- [ ] **Record the result** — note backup location, playbook revision, affected
+  hosts, validation results, and any rollback action in the change record.
+
 ## Steps
 
 1. Ensure inventory is current and credentials are valid.


### PR DESCRIPTION
Fixes #167

## Summary

- Add a single production change checklist covering backup → rolling update → node/VIP failover → Nebula Sync verification
- Cross-link `upgrade-runbook.md`, `failover-testing.md`, and `backup-and-restore.md`
- Mark the final P2 operations-documentation backlog item complete

## Release notes

- Proposed release note sentence:
  - N/A (documentation only)
- Changelog type:
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] `git diff --check`
- [x] Relative runbook links point to existing docs and headings
- [x] `graphify update .`
- [x] Docs-only CI gate green

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit

Made with [Cursor](https://cursor.com)