### PR TITLE
fix(ci): make docs-only path filter actually skip heavy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,12 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3
         with:
+          # "every" makes negation patterns act as exclusions; the default
+          # "some" quantifier lets the bare '**' match everything.
+          predicate-quantifier: every
           filters: |
             docs:
-              - 'docs/**'
-              - '**/*.md'
+              - '{docs/**,**/*.md}'
             code:
               - '**'
               - '!docs/**'

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -34,10 +34,12 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3
         with:
+          # "every" makes negation patterns act as exclusions; the default
+          # "some" quantifier lets the bare '**' match everything.
+          predicate-quantifier: every
           filters: |
             docs:
-              - 'docs/**'
-              - '**/*.md'
+              - '{docs/**,**/*.md}'
             code:
               - '**'
               - '!docs/**'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,10 +35,12 @@ jobs:
           github.event_name != 'schedule'
         uses: dorny/paths-filter@v3
         with:
+          # "every" makes negation patterns act as exclusions; the default
+          # "some" quantifier lets the bare '**' match everything.
+          predicate-quantifier: every
           filters: |
             docs:
-              - 'docs/**'
-              - '**/*.md'
+              - '{docs/**,**/*.md}'
             code:
               - '**'
               - '!docs/**'


### PR DESCRIPTION
## Summary

- Fixes the docs-only CI skip from #166 which never actually skipped anything (observed on docs-only PR #168, where the full matrix ran).
- Root cause: `dorny/paths-filter@v3` defaults to the `some` predicate quantifier, so the bare `'**'` in the `code` filter matched every file and the `'!docs/**'` / `'!**/*.md'` negations were silently ignored — `code` was always `true`.
- Sets `predicate-quantifier: every` on the filter step in `ci.yml`, `security.yml`, and `galaxy-publish.yml`, and merges the `docs` filter's positive patterns into a single brace group (`'{docs/**,**/*.md}'`) since `every` requires all listed patterns to match.

## Validation

- PR #168 run log shows `Filter code = true` listing only `.md` files, confirming the diagnosis.
- This PR touches only workflow YAML, so it will exercise the code path itself: expect `code=true` here and the full matrix to run.
- After merge, a docs-only PR (e.g. rebasing #168) should show `code=false`, the heavy jobs skipped, and the `Docs-only change` + `CI checks complete` jobs green.

## Scope & risk

- CI-only change, three workflow files, no playbook or role changes.
- Low risk: worst case the filter still reports `code=true` and CI behaves exactly as today.

Closes #169

Made with [Cursor](https://cursor.com)