### PR TITLE
fix(ci): rerun blocked release PR checks from Release workflow

### DIFF
--- a/.github/workflows/auto-run-release-please-checks.yml
+++ b/.github/workflows/auto-run-release-please-checks.yml
@@ -2,7 +2,11 @@
 # Release Please opens PRs as github-actions[bot], which GitHub treats as a
 # first-time contributor on public repos. CI workflows then sit in
 # action_required until a maintainer clicks "Approve workflows to run".
-# Rerun those runs under a trusted PAT so checks start automatically.
+#
+# When release-please falls back to GITHUB_TOKEN, GitHub will not trigger
+# pull_request_target workflows for the new PR. The Release workflow therefore
+# reruns blocked checks directly after release-please updates the release PR.
+# This workflow remains as a backup when a PAT opens the PR and the event fires.
 name: Auto-run release please checks
 
 on:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: release-please-${{ github.workflow }}-${{ github.ref }}
@@ -71,6 +72,51 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ steps.release-token.outputs.token }}
+
+  rerun-blocked-release-pr-checks:
+    name: Rerun blocked release PR workflows
+    needs: release-please
+    if: >-
+      github.repository_owner == 'steveyminecraft'
+      && github.ref == 'refs/heads/master'
+      && needs.release-please.result == 'success'
+      && needs.release-please.outputs.release_created != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Rerun workflows awaiting approval on release PR head
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+          RELEASE_BRANCH: release-please--branches--master
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::RELEASE_PLEASE_TOKEN is not set; cannot auto-run blocked release PR workflows."
+            echo "Set RELEASE_PLEASE_TOKEN so release-please opens PRs with a maintainer PAT instead of GITHUB_TOKEN."
+            exit 0
+          fi
+
+          # CI workflows on the release PR may still be created after this job starts.
+          sleep 15
+
+          head_sha="$(gh api "repos/${REPO}/git/ref/heads/${RELEASE_BRANCH}" --jq .object.sha)"
+          echo "Release PR head: ${head_sha}"
+
+          mapfile -t run_ids < <(
+            gh api "repos/${REPO}/actions/runs?head_sha=${head_sha}&per_page=100" \
+              --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id'
+          )
+
+          if [ "${#run_ids[@]}" -eq 0 ]; then
+            echo "No action_required workflow runs for ${head_sha}."
+            exit 0
+          fi
+
+          for run_id in "${run_ids[@]}"; do
+            echo "Rerunning workflow run ${run_id}."
+            gh api -X POST "repos/${REPO}/actions/runs/${run_id}/rerun" || true
+          done
 
   tag-release-candidate:
     name: Tag release candidate for AWS tests

--- a/README.md
+++ b/README.md
@@ -499,8 +499,10 @@ PR quality scaffolding is now included in-repo:
 | [Validate collection for Ansible Galaxy](.github/workflows/galaxy-publish.yml) | Push/PR to `master`, manual | Builds the collection artifact and runs `galaxy-importer` |
 
 The Release workflow uses repository secret **`RELEASE_PLEASE_TOKEN`** for
-opening release PRs and pushing RC tags used by AWS remote tests. If the token
-is unavailable, RC tagging and AWS RC tests are skipped with a warning.
+opening release PRs and pushing RC tags used by AWS remote tests. Without a
+valid token, release-please falls back to `GITHUB_TOKEN`, release PRs are
+authored by `github-actions[bot]`, and CI may wait for manual workflow approval.
+If the token is unavailable, RC tagging and AWS RC tests are skipped with a warning.
 Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
 
 **Install a specific version**:


### PR DESCRIPTION
Fixes #172

## Summary

- Rerun blocked release PR CI from the Release workflow (works even when `pull_request_target` does not fire)
- Clarify README: `RELEASE_PLEASE_TOKEN` must be set to avoid the github-actions[bot] approval gate
- Refreshed `RELEASE_PLEASE_TOKEN` repo secret

## Validation

- [ ] Merge and confirm next release-please PR auto-starts CI without manual approval