### PR TITLE
docs: document production inventory to example mapping

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -51,7 +51,7 @@ Docs are clear at a high level but thin relative to playbook complexity.
 Real inventory (`inventory/rnet.yml`) is gitignored; examples exist but mapping
 is implicit.
 
-- [ ] **Document real inventory → example mapping**
+- [x] **Document real inventory → example mapping** ([#174](https://github.com/steveyminecraft/ansible-pihole/issues/174))
   - In `docs/production-deployment.md`: required vs optional vars, vault file
     layout, HA-specific fields (`pihole_vip_ipv4`, nebula primary/replicas).
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -9,17 +9,157 @@
   - Supported Linux hosts with static/reserved IPs
   - SSH access and privilege escalation
 
-## Inventory guidance
+## Inventory files in this repository
 
-Define production inventory with explicit values for:
+| File | Committed | Purpose |
+|------|-----------|---------|
+| `inventory/rnet.yml` | No (`.gitignore`) | Operator production inventory — hosts, HA, Nebula Sync, Unbound wiring |
+| `inventory/inventory.yaml` | No (`.gitignore`) | Alternate local filename some operators use |
+| `inventory/vagrant.yml` | Yes | Molecule/Vagrant HA lab (VirtualBox `192.168.56.0/24`) |
+| `inventory/vagrant_libvirt.yml` | Yes | Same topology on libvirt (`192.168.121.0/24`) |
+| `inventory/ci/` | Yes | Localhost-only vars for CI syntax/check-mode |
+| `tests/remote/inventories/example-lab-ha.yml` | Yes | Dual-node HA template for remote functional tests |
+| `tests/remote/inventories/example-aws.yml` | Yes | Single-node AWS-style template (HA off) |
 
-- `pihole_environment_variables.FTLCONF_webserver_api_password`
-- `pihole_vip_ipv4` (and optional `pihole_vip_ipv6`)
-- `unbound_*` values when Unbound is enabled
-- `nebula_sync_*` values
-- a `nebula_sync_controller` group with exactly one host that runs the Nebula Sync container
+Production inventory is **never** checked in. Start from
+[`tests/remote/inventories/example-lab-ha.yml`](../tests/remote/inventories/example-lab-ha.yml)
+for a dual-node HA layout, or from [`inventory/vagrant.yml`](../inventory/vagrant.yml)
+when comparing against the Molecule lab. Copy the template outside the repo or
+to a gitignored path such as `inventory/rnet.yml` before filling in real
+addresses and secrets.
 
-Do not reuse any lab-only fixture credentials from Vagrant examples.
+## Recommended production layout
+
+Keep secrets out of plaintext inventory. A common layout:
+
+```text
+inventory/
+  rnet.yml                 # hosts, groups, non-secret vars (gitignored)
+  group_vars/
+    all/
+      vars.yml             # optional shared non-secret defaults
+      vault.yml            # ansible-vault encrypted secrets (gitignored)
+```
+
+Run playbooks with vault when secrets live in `group_vars/all/vault.yml`:
+
+```bash
+ansible-playbook -i inventory/rnet.yml playbooks/bootstrap-pihole.yaml \
+  --ask-vault-pass
+# or: export ANSIBLE_VAULT_PASSWORD_FILE=~/.ansible/vault-pass
+```
+
+Plaintext `rnet.yml` with inline passwords is supported for small homelabs but
+is discouraged — prefer vault for
+`FTLCONF_webserver_api_password` and Nebula Sync credentials.
+
+## Host and group structure (HA)
+
+Dual-node HA expects:
+
+- Two Pi-hole hosts in `all.hosts`, each with:
+  - `ansible_host` — management/DNS IP on the LAN
+  - `priority` — keepalived priority (higher wins when healthy)
+  - `keepalive_role` — `MASTER` or `BACKUP` (initial preference; keepalived still elects)
+- Child group `nebula_sync_controller` with **exactly one** host — the node that
+  runs the Nebula Sync container (`playbooks/sync.yaml` targets this group only)
+- Shared `all.vars` for Pi-hole, VIP, Unbound, and Nebula Sync settings
+
+Example skeleton (replace addresses and use vault for secrets):
+
+```yaml
+all:
+  hosts:
+    pihole-01:
+      ansible_host: 192.0.2.10
+      priority: 110
+      keepalive_role: MASTER
+    pihole-02:
+      ansible_host: 192.0.2.11
+      priority: 100
+      keepalive_role: BACKUP
+  children:
+    nebula_sync_controller:
+      hosts:
+        pihole-01:
+  vars:
+    pihole_compose_dir: /opt/pihole
+    pihole_ha_mode: true
+    pihole_vip_ipv4: 192.0.2.53/24
+    # pihole_vip_ipv6: fd00::53/64   # optional
+    pihole_environment_variables:
+      FTLCONF_webserver_api_password: "{{ vault_pihole_api_password }}"
+      # ... see mapping table below
+    nebula_sync_primary_url: http://192.0.2.10
+    nebula_sync_replicas:
+      - url: http://192.0.2.11
+        # replica credential: same vault var as primary (see nebula_sync README)
+```
+
+Do not reuse lab-only fixture credentials from
+[`inventory/vagrant.yml`](../inventory/vagrant.yml) (`LabOnly-Molecule-Pihole-Password!`,
+`:latest` image tags, `vagrant_env: true`, etc.).
+
+## Variable mapping — production → examples
+
+| Production / operator need | Required for HA bootstrap | `inventory/vagrant.yml` | `example-lab-ha.yml` | Notes |
+|----------------------------|-------------------------|-------------------------|----------------------|-------|
+| SSH access | Yes | `ansible_user`, `ansible_password` (first run) | `ansible_user` | Prefer key-based auth; set `password_lock: true` in production |
+| Compose path | Yes | `pihole_compose_dir` | *(inherit defaults)* | Not role-defaulted; set explicitly |
+| Pi-hole API password | Yes | `pihole_environment_variables.FTLCONF_webserver_api_password` | same key, vault placeholder | Min 16 chars; see [secrets-management.md](secrets-management.md) |
+| HA enabled | Yes | `pihole_ha_mode: true` | `pihole_ha_mode: true` | Drives keepalived roles in bootstrap/update |
+| IPv4 VIP | Yes | `pihole_vip_ipv4` | `pihole_vip_ipv4` | CIDR form, e.g. `192.0.2.53/24` |
+| IPv6 VIP | No | `pihole_vip_ipv6` | — | Omit if not using IPv6 VIP |
+| keepalived per host | Yes | `priority`, `keepalive_role` | same | On each host, not in `vars` only |
+| Nebula controller group | Yes | `nebula_sync_controller` child group | same | **Required** for `playbooks/sync.yaml` |
+| Nebula primary URL | Yes (if syncing) | `nebula_sync_primary_url` | same | HTTP(S) to primary Pi-hole API |
+| Nebula replica list | Yes (if syncing) | `nebula_sync_replicas[]` | same | One entry per replica node |
+| Nebula passwords | Yes (if syncing) | `nebula_sync_primary_password`, replica passwords | vault placeholders | Often same as Pi-hole API password |
+| Unbound enabled | Typical | via `pihole_unbound_upstream`, network vars | `pihole_enable_unbound: true` | See Unbound rows below |
+| Pi-hole image pin | Yes | `:latest` in lab only | *(not set — uses role default)* | Pin `pihole_image` in production |
+| Lab-only toggles | No | `vagrant_env`, `pihole_rocky_network_debug`, `docker_enable_ip_forward` | — | Do not copy to production |
+
+### Unbound and Docker networking (when `pihole_enable_unbound: true`)
+
+| Production need | `inventory/vagrant.yml` | Typical production pattern |
+|-----------------|-------------------------|----------------------------|
+| Shared Docker network | `unbound_network_name`, `pihole_network_name` | e.g. `dns_net` |
+| Unbound container name / port | `unbound_container_name`, `unbound_port` | `unbound`, `5335` |
+| Pi-hole upstream to Unbound | `pihole_unbound_upstream` | `"{{ unbound_container_name }}#{{ unbound_port }}"` |
+| Publish Unbound on host | — | `unbound_publish_to_host: false` (default) |
+| Unbound ACLs | — | `unbound_access_control` for LAN/docker ranges |
+
+### Nebula Sync optional tuning
+
+| Variable | Lab example | Production guidance |
+|----------|-------------|---------------------|
+| `nebula_sync_dir` | `/opt/nebula` | Writable path on controller node |
+| `nebula_sync_cron` | `*/15 * * * *` | Adjust sync cadence |
+| `nebula_sync_full_sync` | `true` in vagrant | `false` unless initial sync |
+| `nebula_sync_use_secret_files` | `true` in role defaults | Keep `true`; see secrets doc |
+| `nebula_sync_run_gravity` | varies | Enable if gravity sync required |
+
+## Required vs optional (quick checklist)
+
+**Required before `bootstrap-pihole.yaml` on HA:**
+
+- [ ] Two (or more) hosts with `ansible_host`, `priority`, `keepalive_role`
+- [ ] `pihole_compose_dir`
+- [ ] `pihole_ha_mode: true`
+- [ ] `pihole_vip_ipv4` (and `pihole_vip_ipv6` if used)
+- [ ] `pihole_environment_variables.FTLCONF_webserver_api_password` (vault)
+- [ ] `nebula_sync_controller` with exactly one host (if using Nebula Sync)
+- [ ] `nebula_sync_primary_url`, `nebula_sync_primary_password`, `nebula_sync_replicas` (if syncing)
+- [ ] Pinned `pihole_image` (avoid `:latest`)
+
+**Commonly optional:**
+
+- `pihole_firewall_deploy`, `pihole_webport_*`, REV_SERVER fields
+- `pihole_vip_ipv6`, custom `unbound_access_control`
+- `github_user_for_ssh_key` (only when deploying SSH keys via `sshd` role)
+
+Role tasks reject known placeholders (`CHANGE_ME`, `Intranet`, `Testing 101`, empty
+values) for Pi-hole and Nebula Sync passwords.
 
 ## Recommended defaults
 
@@ -33,14 +173,27 @@ Do not reuse any lab-only fixture credentials from Vagrant examples.
 Bootstrap:
 
 ```bash
-ansible-playbook -i /path/to/inventory.yml playbooks/bootstrap-pihole.yaml
+ansible-playbook -i inventory/rnet.yml playbooks/bootstrap-pihole.yaml
 ```
 
 Update:
 
 ```bash
-ansible-playbook -i /path/to/inventory.yml playbooks/update-pihole.yaml
+ansible-playbook -i inventory/rnet.yml playbooks/update-pihole.yaml
 ```
 
-Both playbooks run one host at a time and include DNS health gates before moving to
-the next node.
+Nebula Sync (controller node only):
+
+```bash
+ansible-playbook -i inventory/rnet.yml playbooks/sync.yaml
+```
+
+Both bootstrap and update run one host at a time (`serial: 1`) and include DNS
+health gates before moving to the next node. See
+[upgrade-runbook.md](upgrade-runbook.md) for the full production change checklist.
+
+## Related docs
+
+- [secrets-management.md](secrets-management.md) — vault naming, rotation (P3 item 2)
+- [upgrade-runbook.md](upgrade-runbook.md) — rolling update and health gates
+- [tests/remote/README.md](../tests/remote/README.md) — validating inventory against remote scenarios


### PR DESCRIPTION
Fixes #174

## Summary

- Expand `docs/production-deployment.md` with inventory file guide, recommended vault layout, HA group structure, and variable mapping tables (production → vagrant → remote example)
- Document required vs optional vars for HA bootstrap, Nebula Sync, and Unbound networking
- Mark P3 backlog item 1 complete

## Release notes

- Proposed release note sentence: N/A (documentation)
- Changelog type: [x] non-user-facing (`docs`)

## Validation

- [x] Docs-only change (expects lightweight CI skip)

## Scope and risk

- Risk level: [x] low
- Rollback plan: revert PR merge commit

Made with [Cursor](https://cursor.com)