### PR TITLE
feat: add pre-flight inventory validator for HA deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,10 @@ jobs:
           python -m pip install --upgrade jinja2
           python -m unittest discover -s tests/unit -p 'test_*.py'
           python scripts/validate-secure-defaults.py
+          python scripts/validate-inventory.py \
+            tests/remote/inventories/example-lab-ha.yml \
+            inventory/vagrant.yml \
+            --structure-only
 
   ci-success:
     name: CI checks complete

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -58,7 +58,7 @@ is implicit.
 - [x] **Expand `docs/secrets-management.md`** ([#176](https://github.com/steveyminecraft/ansible-pihole/issues/176))
   - Vault naming convention, Nebula Sync password rotation, drift between nodes.
 
-- [ ] **Pre-flight inventory validator**
+- [x] **Pre-flight inventory validator** ([#178](https://github.com/steveyminecraft/ansible-pihole/issues/178))
   - Playbook or script asserting HA completeness and rejecting placeholders
     before bootstrap/update (fail fast vs mid-deploy).
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -192,6 +192,17 @@ Both bootstrap and update run one host at a time (`serial: 1`) and include DNS
 health gates before moving to the next node. See
 [upgrade-runbook.md](upgrade-runbook.md) for the full production change checklist.
 
+### Pre-flight inventory validation
+
+Before bootstrap or update, run:
+
+```bash
+python3 scripts/validate-inventory.py inventory/rnet.yml
+```
+
+Use `--structure-only` to check HA groups and required keys without evaluating
+secret placeholders (useful for vault-backed or template inventories).
+
 ## Related docs
 
 - [secrets-management.md](secrets-management.md) — vault naming, rotation (P3 item 2)

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -158,8 +158,13 @@ ansible-playbook -i inventory/rnet.yml playbooks/sync.yaml
 - Compare Nebula Sync cron and primary URL in inventory with the controller's
   rendered compose under `nebula_sync_dir`.
 
-Use the pre-flight inventory validator (`scripts/validate-inventory.py`) before
-bootstrap or update to catch missing HA groups and placeholder secrets early.
+Use the pre-flight inventory validator before bootstrap or update to catch missing
+HA groups and placeholder secrets early:
+
+```bash
+python3 scripts/validate-inventory.py inventory/rnet.yml
+python3 scripts/validate-inventory.py inventory/rnet.yml --structure-only  # layout only
+```
 
 ## Related docs
 

--- a/scripts/validate-inventory.py
+++ b/scripts/validate-inventory.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Pre-flight checks for Pi-hole HA inventory before bootstrap or update."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REJECTED_SECRET_VALUES = frozenset(
+    {
+        "",
+        "CHANGE_ME",
+        "Intranet",
+        "Testing 101",
+        "REPLACE_WITH_ANSIBLE_VAULT",
+        "LabOnly-Molecule-Pihole-Password!",
+        "replace-me",
+    }
+)
+
+HA_HOST_KEYS = ("ansible_host", "priority", "keepalive_role")
+
+
+def load_ansible_inventory(inventory_path: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        ["ansible-inventory", "-i", str(inventory_path), "--list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ansible-inventory failed for {inventory_path}:\n{result.stderr.strip()}"
+        )
+    return json.loads(result.stdout)
+
+
+def inventory_hosts(inventory: dict[str, Any]) -> list[str]:
+    hostvars = inventory.get("_meta", {}).get("hostvars", {})
+    return sorted(hostvars.keys())
+
+
+def host_var(hostvars: dict[str, Any], host: str, key: str, default: Any = None) -> Any:
+    return hostvars.get(host, {}).get(key, default)
+
+
+def merged_var(hostvars: dict[str, Any], hosts: list[str], key: str, default: Any = None) -> Any:
+    for host in hosts:
+        value = host_var(hostvars, host, key, default=None)
+        if value is not None:
+            return value
+    return default
+
+
+def is_unresolved_secret(value: Any) -> bool:
+    if value is None:
+        return True
+    text = str(value).strip()
+    if "{{" in text and "}}" in text:
+        return False
+    if text in REJECTED_SECRET_VALUES:
+        return True
+    return False
+
+
+def validate_structure(inventory: dict[str, Any], errors: list[str]) -> None:
+    hostvars = inventory.get("_meta", {}).get("hostvars", {})
+    hosts = inventory_hosts(inventory)
+    if not hosts:
+        errors.append("Inventory defines no hosts.")
+        return
+
+    if merged_var(hostvars, hosts, "pihole_compose_dir") in (None, ""):
+        errors.append("Set pihole_compose_dir in inventory (not role-defaulted for production).")
+
+    ha_mode = merged_var(hostvars, hosts, "pihole_ha_mode", False)
+    if not ha_mode:
+        return
+
+    if len(hosts) < 2:
+        errors.append("pihole_ha_mode is true but fewer than two hosts are defined.")
+
+    if not merged_var(hostvars, hosts, "pihole_vip_ipv4"):
+        errors.append("pihole_ha_mode is true but pihole_vip_ipv4 is missing.")
+
+    for host in hosts:
+        for key in HA_HOST_KEYS:
+            if host_var(hostvars, host, key) in (None, ""):
+                errors.append(f"Host {host} is missing required HA key '{key}'.")
+
+    controller_group = inventory.get("nebula_sync_controller", {})
+    hosts_entry = controller_group.get("hosts") or []
+    if isinstance(hosts_entry, dict):
+        controller_hosts = list(hosts_entry.keys())
+    else:
+        controller_hosts = list(hosts_entry)
+    if len(controller_hosts) != 1:
+        errors.append(
+            "nebula_sync_controller group must exist with exactly one host "
+            f"(found {len(controller_hosts)})."
+        )
+
+    primary_url = merged_var(hostvars, hosts, "nebula_sync_primary_url")
+    if primary_url:
+        replicas = merged_var(hostvars, hosts, "nebula_sync_replicas", [])
+        if not replicas:
+            errors.append("nebula_sync_primary_url is set but nebula_sync_replicas is empty.")
+
+
+def validate_secrets(inventory: dict[str, Any], errors: list[str]) -> None:
+    hostvars = inventory.get("_meta", {}).get("hostvars", {})
+    hosts = inventory_hosts(inventory)
+    if not hosts:
+        return
+
+    reference_host = hosts[0]
+    env = host_var(hostvars, reference_host, "pihole_environment_variables", {}) or {}
+    api_password = env.get("FTLCONF_webserver_api_password")
+    if is_unresolved_secret(api_password):
+        errors.append(
+            "Pi-hole FTLCONF_webserver_api_password is missing, placeholder, or vault unresolved."
+        )
+    elif isinstance(api_password, str) and len(api_password) < 16:
+        errors.append("Pi-hole FTLCONF_webserver_api_password must be at least 16 characters.")
+
+    primary_url = merged_var(hostvars, hosts, "nebula_sync_primary_url")
+    if not primary_url:
+        return
+
+    primary_password = merged_var(hostvars, hosts, "nebula_sync_primary_password")
+    if is_unresolved_secret(primary_password):
+        errors.append("nebula_sync_primary_password is missing, placeholder, or vault unresolved.")
+
+    replicas = merged_var(hostvars, hosts, "nebula_sync_replicas", []) or []
+    for index, replica in enumerate(replicas):
+        if not isinstance(replica, dict):
+            errors.append(f"nebula_sync_replicas[{index}] must be a mapping with url and password.")
+            continue
+        if not str(replica.get("url", "")).strip():
+            errors.append(f"nebula_sync_replicas[{index}].url is empty.")
+        replica_password = replica.get("password")
+        if is_unresolved_secret(replica_password):
+            errors.append(
+                f"nebula_sync_replicas[{index}].password is missing, placeholder, or vault unresolved."
+            )
+
+
+def validate_inventory(inventory_path: Path, *, structure_only: bool = False) -> list[str]:
+    inventory = load_ansible_inventory(inventory_path)
+    errors: list[str] = []
+    validate_structure(inventory, errors)
+    if not structure_only:
+        validate_secrets(inventory, errors)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "inventories",
+        nargs="+",
+        type=Path,
+        help="Inventory file or directory passed to ansible-inventory -i",
+    )
+    parser.add_argument(
+        "--structure-only",
+        action="store_true",
+        help="Validate HA layout and groups without checking secret values.",
+    )
+    args = parser.parse_args(argv)
+
+    exit_code = 0
+    for inventory_path in args.inventories:
+        errors = validate_inventory(inventory_path, structure_only=args.structure_only)
+        if errors:
+            exit_code = 1
+            print(f"{inventory_path}: FAIL", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+        else:
+            print(f"{inventory_path}: OK")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/remote/inventories/example-lab-ha.yml
+++ b/tests/remote/inventories/example-lab-ha.yml
@@ -17,6 +17,7 @@ all:
     ansible_user: ansible
     ansible_python_interpreter: /usr/bin/python3
     ansible_user_home_dir: /home/ansible
+    pihole_compose_dir: /opt/pihole
     github_user_for_ssh_key: replace-me
     password_lock: true
     timezone: Etc/UTC

--- a/tests/unit/test_validate_inventory.py
+++ b/tests/unit/test_validate_inventory.py
@@ -1,0 +1,89 @@
+"""Unit tests for scripts/validate-inventory.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "validate-inventory.py"
+REPO = SCRIPT.parents[1]
+EXAMPLE_HA = REPO / "tests/remote/inventories/example-lab-ha.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("validate_inventory", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidateInventoryHelpersTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = load_module()
+
+    def test_unresolved_secret_rejects_placeholders(self) -> None:
+        self.assertTrue(self.mod.is_unresolved_secret("CHANGE_ME"))
+        self.assertTrue(self.mod.is_unresolved_secret("REPLACE_WITH_ANSIBLE_VAULT"))
+
+    def test_unresolved_secret_accepts_vault_jinja(self) -> None:
+        self.assertFalse(self.mod.is_unresolved_secret("{{ vault_pihole_api_password }}"))
+
+    def test_structure_only_passes_example_lab_ha(self) -> None:
+        errors = self.mod.validate_inventory(EXAMPLE_HA, structure_only=True)
+        self.assertEqual(errors, [])
+
+    def test_secret_check_fails_example_lab_ha_placeholders(self) -> None:
+        errors = self.mod.validate_inventory(EXAMPLE_HA, structure_only=False)
+        self.assertTrue(any("FTLCONF_webserver_api_password" in err for err in errors))
+
+    def test_ha_requires_controller_group(self) -> None:
+        inventory = {
+            "_meta": {
+                "hostvars": {
+                    "a": {
+                        "ansible_host": "10.0.0.1",
+                        "priority": 110,
+                        "keepalive_role": "MASTER",
+                        "pihole_compose_dir": "/opt/pihole",
+                        "pihole_ha_mode": True,
+                        "pihole_vip_ipv4": "10.0.0.53/24",
+                    },
+                    "b": {
+                        "ansible_host": "10.0.0.2",
+                        "priority": 100,
+                        "keepalive_role": "BACKUP",
+                        "pihole_compose_dir": "/opt/pihole",
+                        "pihole_ha_mode": True,
+                        "pihole_vip_ipv4": "10.0.0.53/24",
+                    },
+                }
+            }
+        }
+        errors: list[str] = []
+        self.mod.validate_structure(inventory, errors)
+        self.assertTrue(any("nebula_sync_controller" in err for err in errors))
+
+
+class ValidateInventoryCliTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = load_module()
+
+    def test_main_returns_nonzero_on_failure(self) -> None:
+        with mock.patch.object(
+            self.mod,
+            "validate_inventory",
+            return_value=["missing vip"],
+        ):
+            code = self.mod.main([str(EXAMPLE_HA)])
+        self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #178

## Summary

- Add `scripts/validate-inventory.py` for HA layout and secret placeholder checks via `ansible-inventory`
- Unit tests and CI safety step (`--structure-only` on example-lab-ha + vagrant)
- Document usage in production-deployment and secrets-management guides
- Add `pihole_compose_dir` to remote HA example inventory

## Release notes

- Operators can run `python3 scripts/validate-inventory.py inventory/rnet.yml` before bootstrap/update

## Validation

- [x] Unit tests pass locally
- [ ] Full CI matrix

## Scope and risk

- Risk: low — additive script; CI structure-only checks on lab inventories

Made with [Cursor](https://cursor.com)