### PR TITLE
feat: wire upstream image check and enforce CI pin sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,8 @@ jobs:
             tests/remote/inventories/example-lab-ha.yml \
             inventory/vagrant.yml \
             --structure-only
+          python scripts/check-pihole-image-pins.py
+          python scripts/check-pihole-image-upstream.py --fail-on-drift
 
   ci-success:
     name: CI checks complete

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -67,11 +67,11 @@ is implicit.
 Image bumps currently touch multiple files manually (defaults, CI playbooks,
 Trivy legacy list).
 
-- [ ] **Wire upstream image check into CI**
+- [x] **Wire upstream image check into CI** ([#181](https://github.com/steveyminecraft/ansible-pihole/issues/181))
   - `tests/unit/test_check_pihole_image_upstream.py` exists; run in CI
     (informational or blocking on drift).
 
-- [ ] **Single source of truth for image pin**
+- [x] **Single source of truth for image pin** ([#181](https://github.com/steveyminecraft/ansible-pihole/issues/181))
   - Generate CI inventory pins from `roles/pihole/defaults/main.yml` (or
     reverse) so bumps are one-line changes.
 

--- a/scripts/check-pihole-image-pins.py
+++ b/scripts/check-pihole-image-pins.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Ensure CI/lab mirror files use the canonical pihole_image from role defaults."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Files that must mirror roles/pihole/defaults/main.yml pihole_image exactly.
+MIRROR_PATHS = (
+    "inventory/ci/group_vars/all.yml",
+    "playbooks/ci-bootstrap.yaml",
+    "playbooks/ci-validate-pihole-modes.yaml",
+)
+
+PIHOLE_IMAGE_LINE = re.compile(
+    r'^(?P<prefix>\s*pihole_image:\s*")(?P<value>[^"]+)(".*)$',
+    re.MULTILINE,
+)
+
+
+def pinned_pihole_image() -> str:
+    script = ROOT / "scripts" / "default-container-images.py"
+    spec = importlib.util.spec_from_file_location("default_container_images", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.pinned_pihole_image()
+
+
+def read_mirror_value(relative_path: str) -> str | None:
+    path = ROOT / relative_path
+    text = path.read_text(encoding="utf-8")
+    match = PIHOLE_IMAGE_LINE.search(text)
+    if not match:
+        return None
+    return match.group("value")
+
+
+def sync_mirror(relative_path: str, canonical_image: str) -> bool:
+    path = ROOT / relative_path
+    text = path.read_text(encoding="utf-8")
+    updated, count = PIHOLE_IMAGE_LINE.subn(
+        lambda match: f'{match.group("prefix")}{canonical_image}{match.group(3)}',
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise RuntimeError(f"Expected one pihole_image line in {relative_path}, found {count}")
+    if updated == text:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def validate_pins() -> list[str]:
+    canonical = pinned_pihole_image()
+    errors: list[str] = []
+    for relative_path in MIRROR_PATHS:
+        mirror_value = read_mirror_value(relative_path)
+        if mirror_value is None:
+            errors.append(f"{relative_path}: pihole_image line not found")
+        elif mirror_value != canonical:
+            errors.append(
+                f"{relative_path}: pihole_image is {mirror_value!r}, "
+                f"expected canonical {canonical!r} from roles/pihole/defaults/main.yml"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="Rewrite mirror files to match roles/pihole/defaults/main.yml",
+    )
+    args = parser.parse_args(argv)
+
+    canonical = pinned_pihole_image()
+    print(f"Canonical pihole_image: {canonical}")
+
+    if args.sync:
+        for relative_path in MIRROR_PATHS:
+            if sync_mirror(relative_path, canonical):
+                print(f"Updated {relative_path}")
+            else:
+                print(f"Already current: {relative_path}")
+        return 0
+
+    errors = validate_pins()
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        print(
+            "Run: python scripts/check-pihole-image-pins.py --sync",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("All CI mirror pins match role defaults.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-pihole-image-upstream.py
+++ b/scripts/check-pihole-image-upstream.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import re
@@ -12,22 +13,25 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-import yaml
-
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULTS_PATH = ROOT / "roles" / "pihole" / "defaults" / "main.yml"
 DOCKER_HUB_TAGS_URL = (
     "https://hub.docker.com/v2/repositories/pihole/pihole/tags?page_size=100"
 )
 CALENDAR_TAG = re.compile(r"^(?P<year>\d{4})\.(?P<month>\d{2})\.(?P<patch>\d+)$")
 
 
+def _load_default_container_images_module():
+    script = ROOT / "scripts" / "default-container-images.py"
+    spec = importlib.util.spec_from_file_location("default_container_images", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def load_pinned_image() -> str:
-    data = yaml.safe_load(DEFAULTS_PATH.read_text(encoding="utf-8")) or {}
-    image = data.get("pihole_image")
-    if not isinstance(image, str) or ":" not in image:
-        raise RuntimeError(f"Unable to read pihole_image from {DEFAULTS_PATH}")
-    return image
+    return _load_default_container_images_module().pinned_pihole_image()
 
 
 def parse_calendar_tag(tag: str) -> tuple[int, int, int] | None:
@@ -78,6 +82,11 @@ def latest_calendar_tag(tags: list[str]) -> str | None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Exit 1 when Docker Hub has a newer calendar tag than the pinned default.",
+    )
+    parser.add_argument(
         "--github-output",
         action="store_true",
         help="Write update_available, pinned_tag, and latest_tag to GITHUB_OUTPUT",
@@ -116,6 +125,15 @@ def main() -> int:
             f"pinned_image={image}",
         ]
         output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    if args.fail_on_drift and update_available:
+        print(
+            f"Pinned Pi-hole tag {current} is behind Docker Hub latest {latest}. "
+            "Bump roles/pihole/defaults/main.yml and run "
+            "python scripts/check-pihole-image-pins.py --sync.",
+            file=sys.stderr,
+        )
+        return 1
 
     return 0
 

--- a/scripts/default-container-images.py
+++ b/scripts/default-container-images.py
@@ -28,6 +28,14 @@ def load_defaults(role: str) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
+def pinned_pihole_image() -> str:
+    """Canonical Pi-hole image pin from role defaults."""
+    image = load_defaults("pihole").get("pihole_image")
+    if not isinstance(image, str) or ":" not in image:
+        raise RuntimeError("Unable to read pihole_image from roles/pihole/defaults/main.yml")
+    return image
+
+
 def image_key(image: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "-", image).strip("-")
 

--- a/scripts/open_pihole_image_update_issue.py
+++ b/scripts/open_pihole_image_update_issue.py
@@ -30,7 +30,7 @@ Full image reference today: `{pinned_image}`
 ## Suggested follow-up
 
 1. Review the [Pi-hole release notes](https://github.com/pi-hole/pi-hole/releases) and Docker Hub tag `{latest_tag}`.
-2. Bump `pihole_image` in `roles/pihole/defaults/main.yml` and mirrored CI defaults if appropriate.
+2. Bump `pihole_image` in `roles/pihole/defaults/main.yml`, then run `python scripts/check-pihole-image-pins.py --sync`.
 3. Re-run Trivy/security scanning and Molecule or AWS RC tests before merging.
 4. Close this issue after the pin is updated or consciously deferred.
 

--- a/tests/unit/test_check_pihole_image_pins.py
+++ b/tests/unit/test_check_pihole_image_pins.py
@@ -1,0 +1,69 @@
+"""Tests for scripts/check-pihole-image-pins.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PINS_SCRIPT = ROOT / "scripts" / "check-pihole-image-pins.py"
+DEFAULTS_SCRIPT = ROOT / "scripts" / "default-container-images.py"
+
+
+def load_module(script: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {script}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CheckPiholeImagePinsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.pins = load_module(PINS_SCRIPT, "check_pihole_image_pins")
+        cls.defaults = load_module(DEFAULTS_SCRIPT, "default_container_images")
+
+    def test_validate_pins_passes_on_current_repo(self) -> None:
+        self.assertEqual(self.pins.validate_pins(), [])
+
+    def test_sync_updates_mismatching_mirror(self) -> None:
+        canonical = self.defaults.pinned_pihole_image()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mirror = Path(tmpdir) / "ci.yml"
+            mirror.write_text('pihole_image: "pihole/pihole:2099.01.0"\n', encoding="utf-8")
+            text = mirror.read_text(encoding="utf-8")
+            updated, _ = self.pins.PIHOLE_IMAGE_LINE.subn(
+                lambda match: f'{match.group("prefix")}{canonical}{match.group(3)}',
+                text,
+                count=1,
+            )
+            mirror.write_text(updated, encoding="utf-8")
+            self.assertIn(canonical, mirror.read_text(encoding="utf-8"))
+
+
+class CheckPiholeImageUpstreamDriftTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.upstream = load_module(
+            ROOT / "scripts" / "check-pihole-image-upstream.py",
+            "check_pihole_image_upstream",
+        )
+
+    def test_fail_on_drift_when_latest_is_newer(self) -> None:
+        current = self.upstream.parse_calendar_tag("2026.05.0")
+        latest = self.upstream.parse_calendar_tag("2026.06.0")
+        self.assertTrue(latest > current)
+
+    def test_no_drift_when_tags_match(self) -> None:
+        current = self.upstream.parse_calendar_tag("2026.07.2")
+        latest = self.upstream.parse_calendar_tag("2026.07.2")
+        self.assertFalse(latest > current)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_default_container_images.py
+++ b/tests/unit/test_default_container_images.py
@@ -28,6 +28,10 @@ class DefaultContainerImagesTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.helper = load_helper()
 
+    def test_pinned_pihole_image_matches_role_defaults(self) -> None:
+        pihole = self.helper.load_defaults("pihole")
+        self.assertEqual(self.helper.pinned_pihole_image(), pihole["pihole_image"])
+
     def test_default_images_include_each_deployed_service(self) -> None:
         images = set(self.helper.default_images())
         pihole = self.helper.load_defaults("pihole")

--- a/tests/unit/test_update_pihole_playbook.py
+++ b/tests/unit/test_update_pihole_playbook.py
@@ -18,6 +18,7 @@ ROLLING_PLAYBOOKS = (
 )
 UBUNTU_MOLECULE = ROOT / "molecule" / "ubuntu" / "molecule.yml"
 COMPOSE_TEMPLATE = ROOT / "roles" / "pihole" / "templates" / "docker-compose.yml.j2"
+PIHOLE_DEFAULTS = ROOT / "roles" / "pihole" / "defaults" / "main.yml"
 
 
 def load_yaml(path: Path):
@@ -72,10 +73,11 @@ class PiholeComposeTemplateTests(unittest.TestCase):
         cls.env = env
 
     def _render(self, **overrides) -> str:
+        defaults = yaml.safe_load(PIHOLE_DEFAULTS.read_text(encoding="utf-8")) or {}
         variables = {
             "pihole_container_name": "pihole",
             "inventory_hostname": "node1",
-            "pihole_image": "pihole/pihole:2026.07.2",
+            "pihole_image": defaults["pihole_image"],
             "pihole_use_host_network": False,
             "pihole_enable_unbound": True,
             "pihole_network_name": "dns_net",


### PR DESCRIPTION
Fixes #181

## Summary

- Add `pinned_pihole_image()` in `default-container-images.py` as canonical source from `roles/pihole/defaults/main.yml`
- Add `check-pihole-image-pins.py` to validate CI mirrors match defaults (`--sync` to rewrite mirrors after a bump)
- Run upstream Docker Hub drift check (`--fail-on-drift`) and pin validation in CI safety checks
- Compose template test reads `pihole_image` from role defaults

## Release notes

- Image bumps: edit `roles/pihole/defaults/main.yml`, then `python scripts/check-pihole-image-pins.py --sync`

## Validation

- [x] All unit tests pass locally
- [x] Upstream check reports no drift for 2026.07.2
- [ ] Full CI matrix

## Scope and risk

- Risk: low — CI fails when Docker Hub publishes a newer calendar tag until pin is bumped

Made with [Cursor](https://cursor.com)