### PR TITLE
feat: knowledge vault hook, dedupe, and MCP docs (P5)

### DIFF
--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "GRAPHIFY_PYTHON",
+      "args": [
+        "-m",
+        "graphify.serve",
+        "GRAPH_PATH"
+      ],
+      "description": "Local ansible-pihole knowledge graph (graphify-out/graph.json). Replace GRAPHIFY_PYTHON with: cat graphify-out/.graphify_python. Replace GRAPH_PATH with: realpath graphify-out/graph.json"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ inventory/rnet.yml
 
 # graphify knowledge vault (local only — see docs/knowledge-vault.md)
 graphify-out/
+.cursor/mcp.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ Architecture maps and agent context live under `graphify-out/` on your machine o
 ```bash
 ./scripts/setup-knowledge-vault.sh          # fast code graph
 ./scripts/setup-knowledge-vault.sh --full   # how to run full /graphify . build
+./scripts/install-graphify-hook.sh          # post-commit code graph refresh
 ```
 
 See `docs/knowledge-vault.md`. Cursor agents bootstrap automatically when `graph.json` is missing.
+Optional MCP config: copy `.cursor/mcp.json.example` → `.cursor/mcp.json` (local only).

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -79,15 +79,15 @@ Trivy legacy list).
 
 Local graphify setup is valuable; graph quality can be improved.
 
-- [ ] **Install `graphify hook`** for post-commit auto-update
-  - See `docs/knowledge-vault.md` and `./scripts/setup-knowledge-vault.sh`.
+- [x] **Install `graphify hook`** for post-commit auto-update
+  - `./scripts/install-graphify-hook.sh` or `./scripts/setup-knowledge-vault.sh --hook`.
 
-- [ ] **Reduce graph noise**
-  - ~405 isolated nodes; duplicate concepts (e.g. `update-pihole.yaml` vs
-    `update-pihole playbook`). Periodic full rebuild + dedupe pass.
+- [x] **Reduce graph noise**
+  - `scripts/dedupe-graphify-graph.py` merges duplicate concepts; use `--prune-isolated`
+    after a full rebuild.
 
-- [ ] **Optional: graphify MCP server**
-  - Lets Cursor/agents query the graph without shelling out.
+- [x] **Optional: graphify MCP server**
+  - `.cursor/mcp.json.example` — copy to `.cursor/mcp.json` (local, gitignored).
 
 ## Priority 6 — Architecture hygiene (medium-term)
 

--- a/docs/knowledge-vault.md
+++ b/docs/knowledge-vault.md
@@ -11,7 +11,8 @@ Agents and contributors use the graph for architecture questions; humans can bro
 ./scripts/setup-knowledge-vault.sh
 
 # Optional: rebuild code graph after every commit (local only)
-graphify hook install
+./scripts/install-graphify-hook.sh
+# Or: ./scripts/setup-knowledge-vault.sh --hook
 ```
 
 Open the interactive map: `graphify-out/graph.html`  
@@ -64,10 +65,55 @@ graphify explain "molecule/default/molecule.yml"
 
 | Change type | Command |
 |-------------|---------|
-| Python/shell | `graphify update .` |
+| Python/shell | `graphify update .` (automatic with post-commit hook) |
 | Roles, playbooks, docs | `/graphify .` or full rebuild |
+| After full rebuild | `python3 scripts/dedupe-graphify-graph.py --prune-isolated` |
 | Re-export Obsidian | `graphify export obsidian` |
 | Re-export HTML | `graphify export html` |
+
+### Post-commit hook
+
+```bash
+./scripts/install-graphify-hook.sh
+```
+
+Installs graphify's post-commit hook locally. After each commit, changed Python/shell
+files are re-extracted into `graphify-out/graph.json`. Doc and YAML changes still
+need a full `/graphify .` rebuild.
+
+Check status: `graphify hook status`
+
+### Reduce graph noise
+
+Duplicate concepts (e.g. `update-pihole.yaml` in docs vs `update-pihole playbook`
+in playbooks) can appear after a full corpus build. Run a dedupe pass:
+
+```bash
+python3 scripts/dedupe-graphify-graph.py --dry-run          # preview
+python3 scripts/dedupe-graphify-graph.py                    # merge duplicates
+python3 scripts/dedupe-graphify-graph.py --prune-isolated  # also drop isolated nodes
+```
+
+Prefer a periodic full rebuild (`/graphify .`) then dedupe, rather than incremental
+AST-only updates when exploring roles and playbooks.
+
+## Cursor MCP (optional)
+
+Agents can query the graph via MCP instead of shelling out to `graphify query`.
+
+1. Bootstrap the vault: `./scripts/setup-knowledge-vault.sh`
+2. Copy `.cursor/mcp.json.example` to `.cursor/mcp.json` (gitignored)
+3. Replace `GRAPHIFY_PYTHON` and `GRAPH_PATH` with values from your machine:
+
+```bash
+cat graphify-out/.graphify_python   # interpreter path
+realpath graphify-out/graph.json    # absolute graph path
+```
+
+4. Reload Cursor MCP servers
+
+Tools exposed: `query_graph`, `get_node`, `get_neighbors`, `get_community`,
+`god_nodes`, `graph_stats`, `shortest_path`.
 
 ## Security
 

--- a/scripts/dedupe-graphify-graph.py
+++ b/scripts/dedupe-graphify-graph.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Merge duplicate graphify nodes and optionally prune isolated vertices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+LINK_KEYS = ("links", "edges")
+
+
+def link_list(graph: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in LINK_KEYS:
+        links = graph.get(key)
+        if isinstance(links, list):
+            return links
+    return []
+
+
+def set_link_list(graph: dict[str, Any], links: list[dict[str, Any]]) -> None:
+    primary = "links" if "links" in graph else "edges" if "edges" in graph else "links"
+    graph[primary] = links
+    for key in LINK_KEYS:
+        if key != primary and key in graph:
+            graph[key] = []
+
+
+def normalize_concept(label: str) -> str:
+    text = label.lower().strip().strip("`")
+    text = re.sub(r"^playbooks/", "", text)
+    text = re.sub(r"^roles/", "", text)
+    text = text.replace(" playbook", "").replace("playbook", "")
+    text = text.replace(".yaml", "").replace(".yml", "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def node_preference_score(node: dict[str, Any]) -> int:
+    score = 0
+    source_file = str(node.get("source_file", ""))
+    if source_file.startswith(("playbooks/", "roles/", "molecule/")):
+        score += 100
+    elif source_file.startswith("docs/") or source_file == "README.md":
+        score -= 50
+    if node.get("_origin") == "ast":
+        score += 10
+    score += len(str(node.get("label", "")))
+    return score
+
+
+def degree_by_node(links: list[dict[str, Any]]) -> dict[str, int]:
+    degree: dict[str, int] = defaultdict(int)
+    for link in links:
+        source = link.get("source")
+        target = link.get("target")
+        if source:
+            degree[str(source)] += 1
+        if target:
+            degree[str(target)] += 1
+    return degree
+
+
+def merge_duplicate_nodes(
+    nodes: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, str], int]:
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for node in nodes:
+        label = str(node.get("label", ""))
+        key = normalize_concept(label)
+        if not key:
+            continue
+        groups[key].append(node)
+
+    id_map: dict[str, str] = {}
+    merged: list[dict[str, Any]] = []
+    merge_count = 0
+
+    for group in groups.values():
+        if len(group) == 1:
+            merged.append(group[0])
+            continue
+
+        canonical = max(group, key=node_preference_score)
+        canonical_id = str(canonical["id"])
+        aliases = sorted(
+            {
+                str(item.get("label", ""))
+                for item in group
+                if str(item.get("label", "")) != str(canonical.get("label", ""))
+            }
+        )
+        if aliases:
+            canonical = dict(canonical)
+            canonical["aliases"] = aliases
+        merged.append(canonical)
+
+        for item in group:
+            item_id = str(item["id"])
+            if item_id != canonical_id:
+                id_map[item_id] = canonical_id
+                merge_count += 1
+
+    for node in nodes:
+        label = str(node.get("label", ""))
+        if not normalize_concept(label):
+            merged.append(node)
+
+    return merged, id_map, merge_count
+
+
+def rewire_links(
+    links: list[dict[str, Any]], id_map: dict[str, str]
+) -> list[dict[str, Any]]:
+    if not id_map:
+        return links
+
+    rewritten: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    for link in links:
+        updated = dict(link)
+        source = str(updated.get("source", ""))
+        target = str(updated.get("target", ""))
+        updated["source"] = id_map.get(source, source)
+        updated["target"] = id_map.get(target, target)
+        if updated["source"] == updated["target"]:
+            continue
+        relation = str(updated.get("relation", ""))
+        key = (updated["source"], updated["target"], relation)
+        if key in seen:
+            continue
+        seen.add(key)
+        rewritten.append(updated)
+    return rewritten
+
+
+def prune_isolated_nodes(
+    nodes: list[dict[str, Any]], links: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], int]:
+    degree = degree_by_node(links)
+    kept = [node for node in nodes if degree.get(str(node["id"]), 0) > 0]
+    removed = len(nodes) - len(kept)
+    return kept, removed
+
+
+def dedupe_graph(
+    graph: dict[str, Any], *, prune_isolated: bool
+) -> dict[str, Any]:
+    nodes = list(graph.get("nodes", []))
+    links = link_list(graph)
+
+    merged_nodes, id_map, merge_count = merge_duplicate_nodes(nodes)
+    merged_links = rewire_links(links, id_map)
+
+    pruned = 0
+    if prune_isolated:
+        merged_nodes, pruned = prune_isolated_nodes(merged_nodes, merged_links)
+
+    result = dict(graph)
+    result["nodes"] = merged_nodes
+    set_link_list(result, merged_links)
+    result["_dedupe"] = {
+        "merged_nodes": merge_count,
+        "pruned_isolated": pruned,
+    }
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge duplicate graphify concepts and optionally prune isolated nodes."
+    )
+    parser.add_argument(
+        "--graph",
+        type=Path,
+        default=Path("graphify-out/graph.json"),
+        help="Path to graph.json (default: graphify-out/graph.json)",
+    )
+    parser.add_argument(
+        "--prune-isolated",
+        action="store_true",
+        help="Remove nodes with zero link degree after deduplication",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print stats without writing graph.json",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    graph_path = args.graph
+    if not graph_path.is_file():
+        print(f"Graph not found: {graph_path}", file=sys.stderr)
+        return 1
+
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    before_nodes = len(graph.get("nodes", []))
+    before_links = len(link_list(graph))
+    before_isolated = len(
+        [
+            node
+            for node in graph.get("nodes", [])
+            if degree_by_node(link_list(graph)).get(str(node["id"]), 0) == 0
+        ]
+    )
+
+    result = dedupe_graph(graph, prune_isolated=args.prune_isolated)
+    stats = result.pop("_dedupe", {})
+    after_nodes = len(result.get("nodes", []))
+    after_links = len(link_list(result))
+    after_isolated = len(
+        [
+            node
+            for node in result.get("nodes", [])
+            if degree_by_node(link_list(result)).get(str(node["id"]), 0) == 0
+        ]
+    )
+
+    print(
+        f"nodes {before_nodes} -> {after_nodes} "
+        f"(merged {stats.get('merged_nodes', 0)}, pruned {stats.get('pruned_isolated', 0)})"
+    )
+    print(
+        f"links {before_links} -> {after_links}; "
+        f"isolated {before_isolated} -> {after_isolated}"
+    )
+
+    if args.dry_run:
+        return 0
+
+    graph_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-graphify-hook.sh
+++ b/scripts/install-graphify-hook.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install graphify post-commit hook for local knowledge vault refresh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+ensure_graphify() {
+  if command -v graphify >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    echo "Installing graphify via uv tool..."
+    uv tool install --upgrade graphifyy -q
+    return 0
+  fi
+  echo "graphify not found. Install with: uv tool install graphifyy" >&2
+  exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  cat <<'EOF'
+Usage: ./scripts/install-graphify-hook.sh
+
+Installs graphify git hooks (post-commit code graph refresh, post-checkout).
+Local only — nothing is committed to the repository.
+
+Requires graphify (installed automatically via uv when available).
+See docs/knowledge-vault.md.
+EOF
+  exit 0
+fi
+
+ensure_graphify
+
+if [[ ! -f graphify-out/graph.json ]]; then
+  echo "graphify-out/graph.json missing — bootstrapping local graph first..."
+  "$ROOT/scripts/setup-knowledge-vault.sh"
+fi
+
+graphify hook install
+graphify hook status
+
+cat <<'EOF'
+
+Post-commit hook installed. After each commit, graphify re-extracts changed
+Python/shell files into graphify-out/graph.json.
+
+For roles, playbooks, or docs changes, run a full rebuild: /graphify .
+EOF

--- a/scripts/setup-knowledge-vault.sh
+++ b/scripts/setup-knowledge-vault.sh
@@ -50,7 +50,7 @@ write_local_index() {
   mkdir -p graphify-out
   local nodes edges communities commit
   nodes="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len(g.get('nodes',[])))" 2>/dev/null || echo '?')"
-  edges="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len(g.get('edges',[])))" 2>/dev/null || echo '?')"
+  edges="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len(g.get('links', g.get('edges',[]))))" 2>/dev/null || echo '?')"
   communities="$(python3 -c "import json; g=json.load(open('graphify-out/graph.json')); print(len({n.get('community') for n in g.get('nodes',[]) if n.get('community') is not None}))" 2>/dev/null || echo '?')"
   commit="$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
 
@@ -112,8 +112,7 @@ if [[ -f graphify-out/graph.json ]]; then
 fi
 
 if [[ "$INSTALL_HOOK" -eq 1 ]]; then
-  graphify hook install
-  graphify hook status
+  "$ROOT/scripts/install-graphify-hook.sh"
 fi
 
 cat <<EOF

--- a/tests/unit/test_dedupe_graphify_graph.py
+++ b/tests/unit/test_dedupe_graphify_graph.py
@@ -1,0 +1,109 @@
+"""Unit tests for scripts/dedupe-graphify-graph.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dedupe-graphify-graph.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("dedupe_graphify_graph", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DedupeGraphifyGraphTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = load_module()
+
+    def test_normalize_concept_strips_playbook_suffix(self) -> None:
+        self.assertEqual(
+            self.mod.normalize_concept("`playbooks/update-pihole.yaml`"),
+            "update-pihole",
+        )
+        self.assertEqual(
+            self.mod.normalize_concept("update-pihole playbook"),
+            "update-pihole",
+        )
+
+    def test_merge_duplicate_nodes_prefers_playbook_source(self) -> None:
+        nodes = [
+            {
+                "id": "docs_ref",
+                "label": "update-pihole.yaml",
+                "source_file": "docs/production-deployment.md",
+            },
+            {
+                "id": "playbook_ref",
+                "label": "update-pihole playbook",
+                "source_file": "playbooks/update-pihole.yaml",
+            },
+        ]
+        merged, id_map, merge_count = self.mod.merge_duplicate_nodes(nodes)
+        self.assertEqual(merge_count, 1)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["id"], "playbook_ref")
+        self.assertIn("update-pihole.yaml", merged[0]["aliases"])
+        self.assertEqual(id_map["docs_ref"], "playbook_ref")
+
+    def test_rewire_links_follows_id_map(self) -> None:
+        links = [
+            {"source": "docs_ref", "target": "other", "relation": "mentions"},
+            {"source": "other", "target": "docs_ref", "relation": "uses"},
+        ]
+        id_map = {"docs_ref": "playbook_ref"}
+        rewired = self.mod.rewire_links(links, id_map)
+        self.assertEqual(len(rewired), 2)
+        self.assertEqual(rewired[0]["source"], "playbook_ref")
+        self.assertEqual(rewired[1]["target"], "playbook_ref")
+
+    def test_prune_isolated_nodes_removes_zero_degree(self) -> None:
+        nodes = [
+            {"id": "a", "label": "connected"},
+            {"id": "b", "label": "lonely"},
+        ]
+        links = [{"source": "a", "target": "c", "relation": "rel"}]
+        kept, removed = self.mod.prune_isolated_nodes(nodes, links)
+        self.assertEqual(removed, 1)
+        self.assertEqual([node["id"] for node in kept], ["a"])
+
+    def test_main_dry_run_reports_stats(self) -> None:
+        graph = {
+            "nodes": [
+                {
+                    "id": "docs_ref",
+                    "label": "update-pihole.yaml",
+                    "source_file": "docs/production-deployment.md",
+                },
+                {
+                    "id": "playbook_ref",
+                    "label": "update-pihole playbook",
+                    "source_file": "playbooks/update-pihole.yaml",
+                },
+                {"id": "lonely", "label": "orphan", "source_file": "docs/x.md"},
+            ],
+            "links": [
+                {"source": "docs_ref", "target": "playbook_ref", "relation": "same"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            graph_path = Path(tmp) / "graph.json"
+            graph_path.write_text(json.dumps(graph), encoding="utf-8")
+            before = graph_path.read_text(encoding="utf-8")
+            rc = self.mod.main(["--graph", str(graph_path), "--dry-run"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(graph_path.read_text(encoding="utf-8"), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #183. Implements Priority 5 (developer experience / knowledge vault):

- **`scripts/install-graphify-hook.sh`** — one-command post-commit graph refresh (also wired from `setup-knowledge-vault.sh --hook`)
- **`scripts/dedupe-graphify-graph.py`** — merge duplicate concepts (e.g. doc refs vs playbook nodes) with optional `--prune-isolated`
- **`.cursor/mcp.json.example`** — template for Cursor MCP graphify server (local `mcp.json` gitignored)
- Docs updates in `docs/knowledge-vault.md`, `CONTRIBUTING.md`, and backlog checkboxes

Also fixes edge count in `setup-knowledge-vault.sh` to use `links` (graphify's native key).

## Test plan

- [x] `python3 -m unittest tests.unit.test_dedupe_graphify_graph -v`
- [x] `python3 scripts/dedupe-graphify-graph.py --dry-run` on local graph
- [ ] CI green (docs + unit tests)


Made with [Cursor](https://cursor.com)