### PR TITLE
feat: legacy var lint and unified testing guide (P6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,7 @@ jobs:
             --structure-only
           python scripts/check-pihole-image-pins.py
           python scripts/check-pihole-image-upstream.py --fail-on-drift
+          python scripts/check-legacy-inventory-vars.py
 
   ci-success:
     name: CI checks complete

--- a/README.md
+++ b/README.md
@@ -137,7 +137,19 @@ environment subnet (documentation ranges such as `2001:db8::/32` are rejected).
 
 Pi-hole-related variables (e.g. `pihole_environment_variables`, `pihole_ha_mode`, `pihole_vip_ipv4` / `pihole_vip_ipv6`) are typically set in inventory; see the [docker-pi-hole environment docs](https://github.com/pi-hole/docker-pi-hole#environment-variables) for image variables.
 
-Role-local variable naming now consistently uses the `pihole_` prefix to satisfy ansible-lint role scoping rules (for example `pihole_dir_loc`, `pihole_webport_http`, `pihole_docker_manage_iptables`). Existing inventories that still define legacy unprefixed names continue to work via compatibility lookups, but new configs should use the prefixed names.
+Role-local variable naming now consistently uses the `pihole_` prefix to satisfy ansible-lint role scoping rules (for example `pihole_dir_loc`, `pihole_webport_http`, `pihole_docker_manage_iptables`). Existing inventories that still define legacy unprefixed names continue to work via compatibility lookups in `roles/pihole/defaults/main.yml`, but new configs should use the prefixed names.
+
+| Legacy (deprecated) | Use instead | Removal target |
+|---------------------|-------------|----------------|
+| `dir_loc` | `pihole_dir_loc` | v2.0.0 |
+| `firewall_deploy` | `pihole_firewall_deploy` | v2.0.0 |
+| `webport_http` | `pihole_webport_http` | v2.0.0 |
+| `webport_https` | `pihole_webport_https` | v2.0.0 |
+| `docker_manage_iptables` | `pihole_docker_manage_iptables` | v2.0.0 |
+| `docker_el_nat_fallback` | `pihole_docker_el_nat_fallback` | v2.0.0 |
+| `pihole_unbound_verify_qname` | `pihole_verify_qname` | v2.0.0 |
+
+Lint inventories locally: `python scripts/check-legacy-inventory-vars.py` (warn-only; `--fail-on-find` after v2.0.0). See [Testing guide](docs/testing.md).
 
 Pi-hole image pulls map common host architectures to Docker platform strings via
 `pihole_docker_platform_arch_map` (`x86_64`/`amd64` -> `linux/amd64`,
@@ -450,6 +462,7 @@ GitHub repository variables documented in `tests/remote/README.md`.
 - [Git branch workflow](docs/git-branch-workflow.md)
 - [Upgrade runbook](docs/upgrade-runbook.md)
 - [Failover testing](docs/failover-testing.md)
+- [Testing guide](docs/testing.md) — CI, Molecule, AWS remote, manual checks
 - [Backup and restore](docs/backup-and-restore.md)
 - [Secrets management](docs/secrets-management.md)
 - [Knowledge vault (local graphify)](docs/knowledge-vault.md) — optional agent architecture map; `graphify-out/` stays local

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -1,6 +1,7 @@
 # AWS remote tests — workflow guide
 
 This document explains how the GitHub Actions AWS remote test workflows operate, from trigger to teardown.
+For a single index of all test layers (CI, Molecule, AWS, manual), see [Testing guide](testing.md).
 
 There are **two related workflows**. They share the same scripts and AWS setup; they differ mainly in **when they run** and **how much they test**.
 

--- a/docs/failover-testing.md
+++ b/docs/failover-testing.md
@@ -1,6 +1,7 @@
 # Failover Testing
 
 Use Molecule shared HA verification and manual checks to confirm failover behavior.
+See also the [Testing guide](testing.md) for the full CI / Molecule / AWS index.
 
 For planned production changes, reach this page after backup and update through
 the [production change checklist](upgrade-runbook.md#production-change-checklist).

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -91,14 +91,11 @@ Local graphify setup is valuable; graph quality can be improved.
 
 ## Priority 6 — Architecture hygiene (medium-term)
 
-- [ ] **Legacy unprefixed variable deprecation**
-  - README documents compatibility lookups; add deprecation timeline + lint
-    warning for unprefixed names (prefer `pihole_*`).
+- [x] **Legacy unprefixed variable deprecation**
+  - README deprecation table + `scripts/check-legacy-inventory-vars.py` (warn in CI).
 
-- [ ] **Unified testing index**
-  - New or expanded `docs/testing.md`: CI / Molecule / AWS / manual checks in
-    one page (graph suggested splits: Remote HA Inventories, Failover
-    Verification, Molecule scenarios).
+- [x] **Unified testing index**
+  - `docs/testing.md` — CI / Molecule / AWS / manual checks in one page.
 
 ## Priority 7 — CI polish (lower effort)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,129 @@
+# Testing guide
+
+Single index for how this collection is validated: GitHub CI, local Molecule,
+AWS remote tests, and manual production checks.
+
+## Coverage at a glance
+
+| Layer | Where it runs | What it proves | Gap |
+|-------|---------------|----------------|-----|
+| **GitHub CI** | Every PR (code paths) | Lint, syntax, check-mode bootstrap + `update-pihole`, compose validation, script unit tests, inventory structure | No functional HA failover on hosted runners |
+| **Molecule** | Local / self-hosted | Full Vagrant HA bootstrap, rolling update, post-update verify | Not in default GitHub matrix (needs Vagrant) |
+| **AWS remote** | Scheduled + label + manual | Ephemeral EC2 → production playbooks → teardown | Cost; amd64-only on schedule/label |
+| **Manual** | Production change windows | VIP failover, per-node DNS, Nebula Sync | Operator-driven |
+
+---
+
+## GitHub CI (`.github/workflows/ci.yml`)
+
+**Triggers:** pull requests and pushes to `master`.
+
+**Docs-only PRs** skip the heavy Ansible matrix when only documentation changes
+(path filter with `predicate-quantifier: every`).
+
+| Job | Purpose |
+|-----|---------|
+| PR title check | Conventional commit format on PR titles |
+| Lint | `ansible-lint`, `yamllint`, Molecule YAML schema smoke |
+| Ansible tests (Ubuntu matrix) | Syntax + check-mode for `bootstrap-pihole.yaml`, `update-pihole.yaml`; `ci-validate-pihole-modes.yaml` |
+| Policy & script validation | Python unit tests, `validate-secure-defaults.py`, `validate-inventory.py`, image pin/upstream checks, legacy variable lint |
+| Security | CodeQL, Trivy filesystem + pinned container images |
+| Galaxy build | Collection build for advertised ansible-core range |
+
+**Python unit tests:** `python -m unittest discover -s tests/unit -p 'test_*.py'`
+
+**Inventory checks (structure-only in CI):**
+
+```bash
+python scripts/validate-inventory.py \
+  tests/remote/inventories/example-lab-ha.yml \
+  inventory/vagrant.yml \
+  --structure-only
+python scripts/check-legacy-inventory-vars.py
+```
+
+---
+
+## Molecule (local integration)
+
+Six scenarios under `molecule/`:
+
+| Scenario | Path | Focus |
+|----------|------|-------|
+| `ubuntu` | `molecule/ubuntu/` | Ubuntu 24.04 HA — bootstrap, verify, rolling `update-pihole`, re-verify |
+| `ubuntu-26.04` | `molecule/ubuntu-26.04/` | Ubuntu 26.04 — same HA + update sequence |
+| `default` | `molecule/default/` | Rocky-style lab box |
+| `docker` | `molecule/docker/` | Docker role focus |
+| `pihole-no-unbound` | `molecule/pihole-no-unbound/` | Pi-hole-only DNS bootstrap + update |
+| `nebula-sync-migration` | `molecule/nebula-sync-migration/` | Legacy plaintext → secret-file credential migration |
+
+**Typical HA run:**
+
+```bash
+molecule test -s ubuntu
+```
+
+Sequence: dependency → syntax → create (Vagrant) → prepare → converge → verify →
+**side_effect** (`update-pihole`) → verify → destroy.
+
+Shared verify logic: `molecule/common/verify_ha.yml` and tasks under
+`molecule/common/verify/`.
+
+**Helpers:**
+
+```bash
+./scripts/molecule-vagrant test -s ubuntu
+./scripts/molecule-test-all --ubuntu-only
+```
+
+See [README — Molecule integration tests](../README.md#molecule-integration-tests) for provider notes (VirtualBox vs libvirt, ARM64, box selection).
+
+---
+
+## AWS remote tests
+
+Two workflows share scripts under `tests/remote/`:
+
+| Workflow | File | When |
+|----------|------|------|
+| RC gate | `.github/workflows/rc-aws-remote-tests.yml` | RC tags (`v*-rc*`) |
+| Remote tests | `.github/workflows/aws-remote-tests.yml` | 1st & 15th monthly on `master`, PR label `run-aws-tests`, or manual dispatch |
+
+Flow: OIDC → launch EC2 → `bootstrap-pihole.yaml` → verify → optional `update-pihole.yaml` → verify → always destroy.
+
+**Detail:** [AWS remote tests — workflow guide](aws-remote-tests-workflow.md)  
+**Auth / repo variables:** [AWS remote tests auth](aws-remote-tests-auth.md)
+
+**Manual dispatch highlights:**
+
+- `scenario`: `pihole-unbound` or `pihole-upstream-only`
+- `platform_coverage`: `one-arch` or `all-archs`
+- `skip_update`: skip rolling update playbook
+
+---
+
+## Manual production checks
+
+Use during planned changes (see [upgrade runbook](upgrade-runbook.md)):
+
+1. **Per-node DNS** — `dig +short @<node-ip> <pihole_verify_qname>`
+2. **VIP DNS** — `dig +short @<vip> <pihole_verify_qname>`
+3. **Failover / failback** — simulate primary outage; confirm VIP and DNS
+4. **Nebula Sync** — replication after HA nodes are healthy
+
+**Detail:** [Failover testing](failover-testing.md)
+
+**Pre-flight inventory (before bootstrap or update):**
+
+```bash
+python scripts/validate-inventory.py -i your-inventory.yml
+python scripts/check-legacy-inventory-vars.py path/to/your-inventory.yml
+```
+
+---
+
+## Related docs
+
+- [Production deployment](production-deployment.md) — inventory mapping, health gates
+- [Improvement backlog](improvement-backlog.md) — planned test gaps
+- [Knowledge vault](knowledge-vault.md) — architecture graph for agents

--- a/scripts/check-legacy-inventory-vars.py
+++ b/scripts/check-legacy-inventory-vars.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Warn when inventory YAML still defines legacy unprefixed Pi-hole variables."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - CI always has PyYAML
+    yaml = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Legacy inventory keys accepted by roles/pihole compatibility lookups.
+DEPRECATED_VARS: dict[str, tuple[str, str]] = {
+    "dir_loc": ("pihole_dir_loc", "v2.0.0"),
+    "firewall_deploy": ("pihole_firewall_deploy", "v2.0.0"),
+    "webport_http": ("pihole_webport_http", "v2.0.0"),
+    "webport_https": ("pihole_webport_https", "v2.0.0"),
+    "docker_manage_iptables": ("pihole_docker_manage_iptables", "v2.0.0"),
+    "docker_el_nat_fallback": ("pihole_docker_el_nat_fallback", "v2.0.0"),
+    "pihole_unbound_verify_qname": ("pihole_verify_qname", "v2.0.0"),
+}
+
+DEFAULT_SCAN_ROOTS = (
+    REPO_ROOT / "inventory",
+    REPO_ROOT / "tests" / "remote" / "inventories",
+    REPO_ROOT / "molecule",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    key: str
+    replacement: str
+    removal: str
+
+
+def inventory_yaml_files(roots: Iterable[Path]) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.yml")) + sorted(root.rglob("*.yaml")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel.startswith("molecule/") and "/group_vars/" not in rel and "/host_vars/" not in rel:
+                continue
+            if "/tasks/" in rel or "/handlers/" in rel or "/verify/" in rel:
+                continue
+            if path.name in {"converge.yml", "converge.yaml", "prepare.yml", "verify.yml"}:
+                continue
+            files.append(path)
+    return files
+
+
+def walk_mapping(
+    node: Any,
+    *,
+    path: Path,
+    prefix: str,
+    findings: list[Finding],
+) -> None:
+    if not isinstance(node, dict):
+        return
+    for key, value in node.items():
+        key_text = str(key)
+        dotted = f"{prefix}.{key_text}" if prefix else key_text
+        if key_text in DEPRECATED_VARS:
+            replacement, removal = DEPRECATED_VARS[key_text]
+            findings.append(
+                Finding(
+                    path=path,
+                    key=dotted,
+                    replacement=replacement,
+                    removal=removal,
+                )
+            )
+        if isinstance(value, dict):
+            walk_mapping(value, path=path, prefix=dotted, findings=findings)
+
+
+def scan_file(path: Path) -> list[Finding]:
+    if yaml is None:
+        raise SystemExit("PyYAML is required (pip install pyyaml)")
+    findings: list[Finding] = []
+    try:
+        documents = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+    except yaml.YAMLError as exc:
+        print(f"{path}: unable to parse YAML ({exc})", file=sys.stderr)
+        return findings
+    for document in documents:
+        if document is None:
+            continue
+        walk_mapping(document, path=path, prefix="", findings=findings)
+    return findings
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Inventory files or directories (default: inventory/, tests/remote/inventories/, molecule group/host vars)",
+    )
+    parser.add_argument(
+        "--fail-on-find",
+        action="store_true",
+        help="Exit 1 when deprecated variables are found (default: warn only)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.paths:
+        targets: list[Path] = []
+        for path in args.paths:
+            if path.is_dir():
+                targets.extend(inventory_yaml_files([path]))
+            elif path.is_file():
+                targets.append(path)
+            else:
+                print(f"{path}: not found", file=sys.stderr)
+                return 1
+    else:
+        targets = inventory_yaml_files(DEFAULT_SCAN_ROOTS)
+
+    all_findings: list[Finding] = []
+    for path in targets:
+        all_findings.extend(scan_file(path))
+
+    if not all_findings:
+        print(f"OK — no legacy unprefixed variables in {len(targets)} file(s)")
+        return 0
+
+    for finding in all_findings:
+        try:
+            rel = finding.path.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = finding.path
+        print(
+            f"WARN {rel}: `{finding.key}` is deprecated; "
+            f"use `{finding.replacement}` (removal target {finding.removal})",
+            file=sys.stderr,
+        )
+
+    print(
+        f"Found {len(all_findings)} deprecated variable(s) in {len({f.path for f in all_findings})} file(s)",
+        file=sys.stderr,
+    )
+    return 1 if args.fail_on_find else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_legacy_inventory_vars.py
+++ b/tests/unit/test_check_legacy_inventory_vars.py
@@ -1,0 +1,68 @@
+"""Unit tests for scripts/check-legacy-inventory-vars.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check-legacy-inventory-vars.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_legacy_inventory_vars", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CheckLegacyInventoryVarsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = load_module()
+
+    def test_scan_file_flags_legacy_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            inventory = Path(tmp) / "lab.yml"
+            inventory.write_text(
+                "all:\n  vars:\n    webport_http: '8080'\n    pihole_dir_loc: /opt/pihole\n",
+                encoding="utf-8",
+            )
+            findings = self.mod.scan_file(inventory)
+            self.assertEqual(len(findings), 1)
+            self.assertEqual(findings[0].key, "all.vars.webport_http")
+            self.assertEqual(findings[0].replacement, "pihole_webport_http")
+
+    def test_main_warn_only_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            inventory = Path(tmp) / "lab.yml"
+            inventory.write_text("all:\n  vars:\n    dir_loc: /opt/pihole\n", encoding="utf-8")
+            rc = self.mod.main([str(inventory)])
+            self.assertEqual(rc, 0)
+
+    def test_main_fail_on_find_exits_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            inventory = Path(tmp) / "lab.yml"
+            inventory.write_text("all:\n  vars:\n    dir_loc: /opt/pihole\n", encoding="utf-8")
+            rc = self.mod.main([str(inventory), "--fail-on-find"])
+            self.assertEqual(rc, 1)
+
+    def test_scan_file_clean_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            inventory = Path(tmp) / "lab.yml"
+            inventory.write_text(
+                "all:\n  vars:\n    pihole_webport_http: '80'\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(self.mod.scan_file(inventory), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #185. Priority 6 (architecture hygiene):

- **Deprecation table** in README for legacy unprefixed Pi-hole inventory vars (removal target v2.0.0)
- **`scripts/check-legacy-inventory-vars.py`** — warn-only scan in CI; `--fail-on-find` for future strict mode
- **`docs/testing.md`** — single index for CI, Molecule, AWS remote, and manual checks

## Test plan

- [x] `python3 -m unittest tests.unit.test_check_legacy_inventory_vars -v`
- [x] `python3 scripts/check-legacy-inventory-vars.py` (clean on repo inventories)
- [ ] CI green


Made with [Cursor](https://cursor.com)