### PR TITLE
feat: Molecule docker-ci smoke and HA PR checklist (P7)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,13 @@
 - [ ] Molecule or remote functional checks run when behavior changes
 - [ ] README/operational docs updated when needed
 
+## HA / failover changes (when applicable)
+
+If this PR touches keepalived, VIP failover, rolling updates (`update-pihole.yaml`), or HA verification:
+
+- [ ] Ran `molecule test -s ubuntu` locally (or noted why not — e.g. no Vagrant box)
+- [ ] Updated [failover testing](docs/failover-testing.md) / runbooks if operator steps changed
+
 ## Scope and risk
 
 - Risk level:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,7 @@ jobs:
             'ansible-core>=2.20.5,<2.21' \
             'molecule>=26.6.0' \
             'molecule-docker>=2.1.0' \
+            'molecule-vagrant>=2.0.0' \
             'python-docker>=0.2.0'
 
       - name: Run molecule/docker-ci (docker driver, no Vagrant)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,18 +294,12 @@ jobs:
       - name: Install Molecule tooling
         run: |
           python -m pip install --upgrade pip
-          # ansible-core 2.21 rejects molecule-docker's string `when:` expressions;
-          # pin 2.20 for this smoke job until molecule-docker catches up.
-          python -m pip install --upgrade \
-            'ansible-core>=2.20.5,<2.21' \
-            'molecule>=26.6.0' \
-            'molecule-docker>=2.1.0' \
-            'molecule-vagrant>=2.0.0' \
-            'python-docker>=0.2.0'
+          python -m pip install --upgrade -r requirements.txt
 
       - name: Run molecule/docker-ci (docker driver, no Vagrant)
         env:
           MOLECULE_PROJECT_DIRECTORY: ${{ github.workspace }}
+          ANSIBLE_CONFIG: ${{ github.workspace }}/molecule/docker-ci/ansible.cfg
         run: molecule test -s docker-ci
 
   ci-success:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,9 @@ jobs:
       - name: Run molecule/docker-ci (docker driver, no Vagrant)
         env:
           MOLECULE_PROJECT_DIRECTORY: ${{ github.workspace }}
+          # molecule-docker create/destroy playbooks use string truthiness in `when:`;
+          # allowed until upstream fixes ansible-core 2.21+ conditional typing.
+          ALLOW_BROKEN_CONDITIONALS: "1"
         run: molecule test -s docker-ci
 
   ci-success:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,14 +294,17 @@ jobs:
       - name: Install Molecule tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade -r requirements.txt
+          # ansible-core 2.21 rejects molecule-docker's string `when:` expressions;
+          # pin 2.20 for this smoke job until molecule-docker catches up.
+          python -m pip install --upgrade \
+            'ansible-core>=2.20.5,<2.21' \
+            'molecule>=26.6.0' \
+            'molecule-docker>=2.1.0' \
+            'python-docker>=0.2.0'
 
       - name: Run molecule/docker-ci (docker driver, no Vagrant)
         env:
           MOLECULE_PROJECT_DIRECTORY: ${{ github.workspace }}
-          # molecule-docker create/destroy playbooks use string truthiness in `when:`;
-          # allowed until upstream fixes ansible-core 2.21+ conditional typing.
-          ALLOW_BROKEN_CONDITIONALS: "1"
         run: molecule test -s docker-ci
 
   ci-success:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,7 @@ jobs:
               "molecule/default/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
               "molecule/nebula-sync-migration/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
               "molecule/pihole-no-unbound/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
+              "molecule/docker-ci/molecule.yml": ["dependency", "driver", "platforms", "provisioner", "scenario"],
           }
           for relpath, keys in required.items():
               path = Path(relpath)
@@ -270,6 +271,36 @@ jobs:
           python scripts/check-pihole-image-upstream.py --fail-on-drift
           python scripts/check-legacy-inventory-vars.py
 
+  molecule-docker-smoke:
+    name: Molecule docker driver smoke
+    runs-on: ubuntu-24.04
+    needs: [changes, ansible-tests-ubuntu]
+    if: >-
+      always() &&
+      needs.ansible-tests-ubuntu.result == 'success' &&
+      (
+        needs.changes.outputs.code == 'true' ||
+        github.event_name == 'workflow_dispatch'
+      )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install Molecule tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade -r requirements.txt
+
+      - name: Run molecule/docker-ci (docker driver, no Vagrant)
+        env:
+          MOLECULE_PROJECT_DIRECTORY: ${{ github.workspace }}
+        run: molecule test -s docker-ci
+
   ci-success:
     name: CI checks complete
     runs-on: ubuntu-24.04
@@ -280,6 +311,7 @@ jobs:
       - lint
       - ansible-tests-ubuntu
       - ci-safety-checks
+      - molecule-docker-smoke
     if: always()
     steps:
       - name: Validate CI outcome for change set
@@ -290,6 +322,7 @@ jobs:
           LINT: ${{ needs.lint.result }}
           ANSIBLE: ${{ needs.ansible-tests-ubuntu.result }}
           SAFETY: ${{ needs.ci-safety-checks.result }}
+          MOLECULE: ${{ needs.molecule-docker-smoke.result }}
           EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
@@ -304,6 +337,10 @@ jobs:
             fi
             if [ "$EVENT" = "pull_request" ] && [ "$SAFETY" != "success" ]; then
               echo "PR safety checks did not succeed."
+              exit 1
+            fi
+            if [ "$MOLECULE" != "success" ] && [ "$MOLECULE" != "skipped" ]; then
+              echo "Molecule docker smoke did not succeed (result=${MOLECULE})."
               exit 1
             fi
           else

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -99,12 +99,11 @@ Local graphify setup is valuable; graph quality can be improved.
 
 ## Priority 7 — CI polish (lower effort)
 
-- [ ] **Molecule in CI alternatives**
-  - Vanilla GitHub runners can't run Vagrant easily.
-  - Options: self-hosted runner, or smoke job on `molecule/docker` (no Vagrant).
+- [x] **Molecule in CI alternatives**
+  - `molecule/docker-ci` scenario (docker driver) + CI job `molecule-docker-smoke`.
 
-- [ ] **PR template checkbox for HA changes**
-  - Add: "Ran `molecule test -s ubuntu` locally" for HA-touching PRs.
+- [x] **PR template checkbox for HA changes**
+  - "Ran `molecule test -s ubuntu` locally" in `.github/pull_request_template.md`.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,8 +7,8 @@ AWS remote tests, and manual production checks.
 
 | Layer | Where it runs | What it proves | Gap |
 |-------|---------------|----------------|-----|
-| **GitHub CI** | Every PR (code paths) | Lint, syntax, check-mode bootstrap + `update-pihole`, compose validation, script unit tests, inventory structure | No functional HA failover on hosted runners |
-| **Molecule** | Local / self-hosted | Full Vagrant HA bootstrap, rolling update, post-update verify | Not in default GitHub matrix (needs Vagrant) |
+| **GitHub CI** | Every PR (code paths) | Lint, syntax, check-mode bootstrap + `update-pihole`, compose validation, script unit tests, inventory structure, **Molecule `docker-ci` smoke** | No functional HA failover on hosted runners |
+| **Molecule** | Local / self-hosted | Full Vagrant HA bootstrap, rolling update, post-update verify | HA scenarios not in default GitHub matrix (needs Vagrant) |
 | **AWS remote** | Scheduled + label + manual | Ephemeral EC2 → production playbooks → teardown | Cost; amd64-only on schedule/label |
 | **Manual** | Production change windows | VIP failover, per-node DNS, Nebula Sync | Operator-driven |
 
@@ -27,6 +27,7 @@ AWS remote tests, and manual production checks.
 | Lint | `ansible-lint`, `yamllint`, Molecule YAML schema smoke |
 | Ansible tests (Ubuntu matrix) | Syntax + check-mode for `bootstrap-pihole.yaml`, `update-pihole.yaml`; `ci-validate-pihole-modes.yaml` |
 | Policy & script validation | Python unit tests, `validate-secure-defaults.py`, `validate-inventory.py`, image pin/upstream checks, legacy variable lint |
+| Molecule docker smoke | `molecule test -s docker-ci` — docker role on docker driver (no Vagrant) |
 | Security | CodeQL, Trivy filesystem + pinned container images |
 | Galaxy build | Collection build for advertised ansible-core range |
 
@@ -53,9 +54,19 @@ Six scenarios under `molecule/`:
 | `ubuntu` | `molecule/ubuntu/` | Ubuntu 24.04 HA — bootstrap, verify, rolling `update-pihole`, re-verify |
 | `ubuntu-26.04` | `molecule/ubuntu-26.04/` | Ubuntu 26.04 — same HA + update sequence |
 | `default` | `molecule/default/` | Rocky-style lab box |
-| `docker` | `molecule/docker/` | Docker role focus |
+| `docker` | `molecule/docker/` | Docker role focus (Vagrant — local) |
+| `docker-ci` | `molecule/docker-ci/` | Docker role on docker driver (hosted CI smoke) |
 | `pihole-no-unbound` | `molecule/pihole-no-unbound/` | Pi-hole-only DNS bootstrap + update |
 | `nebula-sync-migration` | `molecule/nebula-sync-migration/` | Legacy plaintext → secret-file credential migration |
+
+**Hosted CI smoke (no Vagrant):**
+
+```bash
+molecule test -s docker-ci
+```
+
+Runs in GitHub Actions on code-changing PRs. Full HA still requires local
+`molecule test -s ubuntu` (see PR template checkbox).
 
 **Typical HA run:**
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,9 +65,9 @@ Six scenarios under `molecule/`:
 molecule test -s docker-ci
 ```
 
-Runs in GitHub Actions on code-changing PRs. Exercises docker role apt repository
-tasks and validates Docker CLI access via the mounted host socket — not a full
-in-container `docker.service` start (that path stays on local Vagrant scenarios).
+Runs in GitHub Actions on code-changing PRs. Exercises docker role `debian_repo`
+tasks inside a docker-driver Molecule container — not a full in-container
+`docker.service` start (that path stays on local Vagrant scenarios).
 Full HA still requires local `molecule test -s ubuntu` (see PR template checkbox).
 
 **Typical HA run:**

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,8 +65,10 @@ Six scenarios under `molecule/`:
 molecule test -s docker-ci
 ```
 
-Runs in GitHub Actions on code-changing PRs. Full HA still requires local
-`molecule test -s ubuntu` (see PR template checkbox).
+Runs in GitHub Actions on code-changing PRs. Exercises docker role apt repository
+tasks and validates Docker CLI access via the mounted host socket — not a full
+in-container `docker.service` start (that path stays on local Vagrant scenarios).
+Full HA still requires local `molecule test -s ubuntu` (see PR template checkbox).
 
 **Typical HA run:**
 

--- a/molecule/docker-ci/ansible.cfg
+++ b/molecule/docker-ci/ansible.cfg
@@ -1,3 +1,5 @@
 [defaults]
 # molecule-docker create/destroy playbooks use string truthiness in `when:`.
 allow_broken_conditionals = true
+roles_path = ../../roles
+collections_path = ../../.ansible/collections:../../collections

--- a/molecule/docker-ci/ansible.cfg
+++ b/molecule/docker-ci/ansible.cfg
@@ -3,3 +3,5 @@
 allow_broken_conditionals = true
 roles_path = ../../roles
 collections_path = ../../.ansible/collections:../../collections
+remote_tmp = /tmp/.ansible-tmp
+local_tmp = /tmp/.ansible-local-tmp

--- a/molecule/docker-ci/ansible.cfg
+++ b/molecule/docker-ci/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+# molecule-docker create/destroy playbooks use string truthiness in `when:`.
+allow_broken_conditionals = true

--- a/molecule/docker-ci/converge.yml
+++ b/molecule/docker-ci/converge.yml
@@ -1,3 +1,22 @@
 ---
-- name: Converge — docker role smoke (CI)
-  import_playbook: ../default/converge-docker.yml
+# CI smoke: exercise docker role apt wiring without starting docker.service inside
+# the Molecule container (systemd + DinD is unreliable on hosted runners).
+# Full docker role coverage remains in molecule/docker (Vagrant).
+- name: Converge — docker role CI smoke
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    docker_manage_iptables: false
+    docker_enable_ip_forward: true
+  tasks:
+    - name: Configure Docker apt repository (Debian family)
+      ansible.builtin.import_role:
+        name: steveyminecraft.pihole.docker
+        tasks_from: debian_repo.yml
+
+    - name: Verify docker CLI reaches host daemon via mounted socket
+      ansible.builtin.command: docker info
+      register: _docker_info
+      changed_when: false
+      failed_when: _docker_info.rc != 0

--- a/molecule/docker-ci/converge.yml
+++ b/molecule/docker-ci/converge.yml
@@ -1,0 +1,3 @@
+---
+- name: Converge — docker role smoke (CI)
+  import_playbook: ../default/converge-docker.yml

--- a/molecule/docker-ci/converge.yml
+++ b/molecule/docker-ci/converge.yml
@@ -14,15 +14,3 @@
       ansible.builtin.import_role:
         name: steveyminecraft.pihole.docker
         tasks_from: debian_repo.yml
-
-    - name: Install Docker CLI for socket smoke check (Debian family)
-      ansible.builtin.apt:
-        name: docker-ce-cli
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Verify docker CLI reaches host daemon via mounted socket
-      ansible.builtin.command: docker info
-      register: _docker_info
-      changed_when: false
-      failed_when: _docker_info.rc != 0

--- a/molecule/docker-ci/converge.yml
+++ b/molecule/docker-ci/converge.yml
@@ -15,6 +15,12 @@
         name: steveyminecraft.pihole.docker
         tasks_from: debian_repo.yml
 
+    - name: Install Docker CLI for socket smoke check (Debian family)
+      ansible.builtin.apt:
+        name: docker-ce-cli
+        state: present
+      when: ansible_facts['os_family'] == 'Debian'
+
     - name: Verify docker CLI reaches host daemon via mounted socket
       ansible.builtin.command: docker info
       register: _docker_info

--- a/molecule/docker-ci/molecule.yml
+++ b/molecule/docker-ci/molecule.yml
@@ -20,6 +20,10 @@ platforms:
       - /run
 provisioner:
   name: ansible
+  inventory:
+    host_vars:
+      docker-ci-01:
+        docker_manage_service: false
   env:
     ANSIBLE_CONFIG: ${MOLECULE_PROJECT_DIRECTORY}/molecule/docker-ci/ansible.cfg
     ANSIBLE_INJECT_FACTS_AS_VARS: "false"

--- a/molecule/docker-ci/molecule.yml
+++ b/molecule/docker-ci/molecule.yml
@@ -21,6 +21,7 @@ platforms:
 provisioner:
   name: ansible
   env:
+    ANSIBLE_CONFIG: ${MOLECULE_PROJECT_DIRECTORY}/molecule/docker-ci/ansible.cfg
     ANSIBLE_INJECT_FACTS_AS_VARS: "false"
     ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
     ANSIBLE_COLLECTIONS_PATH: ${MOLECULE_PROJECT_DIRECTORY}/collections:${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections

--- a/molecule/docker-ci/molecule.yml
+++ b/molecule/docker-ci/molecule.yml
@@ -13,11 +13,11 @@ platforms:
     privileged: true
     cgroupns_mode: host
     volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /var/run/docker.sock:/var/run/docker.sock
     command: /lib/systemd/systemd
     tmpfs:
       - /run
-      - /tmp
 provisioner:
   name: ansible
   env:
@@ -26,6 +26,7 @@ provisioner:
     ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
     ANSIBLE_COLLECTIONS_PATH: ${MOLECULE_PROJECT_DIRECTORY}/collections:${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections
   playbooks:
+    prepare: prepare.yml
     converge: converge.yml
 verifier:
   name: ansible
@@ -35,5 +36,6 @@ scenario:
     - dependency
     - syntax
     - create
+    - prepare
     - converge
     - destroy

--- a/molecule/docker-ci/molecule.yml
+++ b/molecule/docker-ci/molecule.yml
@@ -1,0 +1,38 @@
+---
+# Hosted-CI Molecule smoke: docker role on docker driver (no Vagrant).
+# Local Vagrant iteration remains in molecule/docker/.
+dependency:
+  name: shell
+  command: ${MOLECULE_PROJECT_DIRECTORY}/scripts/install-ansible-collections.sh
+driver:
+  name: docker
+platforms:
+  - name: docker-ci-01
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    pre_build_image: true
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: /lib/systemd/systemd
+    tmpfs:
+      - /run
+      - /tmp
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_INJECT_FACTS_AS_VARS: "false"
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+    ANSIBLE_COLLECTIONS_PATH: ${MOLECULE_PROJECT_DIRECTORY}/collections:${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: ansible
+scenario:
+  name: docker-ci
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - converge
+    - destroy

--- a/molecule/docker-ci/prepare.yml
+++ b/molecule/docker-ci/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare docker-ci instance
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Ensure ansible remote temp directory exists
+      ansible.builtin.file:
+        path: /tmp/.ansible-tmp
+        state: directory
+        mode: "1777"

--- a/molecule/docker-ci/prepare.yml
+++ b/molecule/docker-ci/prepare.yml
@@ -1,5 +1,7 @@
 ---
-- name: Prepare docker-ci instance
+- import_playbook: ../common/prepare.yml
+
+- name: Prepare docker-ci ansible temp
   hosts: all
   gather_facts: false
   tasks:

--- a/molecule/docker-ci/prepare.yml
+++ b/molecule/docker-ci/prepare.yml
@@ -1,7 +1,8 @@
 ---
-- import_playbook: ../common/prepare.yml
+- name: Prepare docker-ci instance (shared packages + apt cache)
+  import_playbook: ../common/prepare.yml
 
-- name: Prepare docker-ci ansible temp
+- name: Prepare docker-ci instance extras
   hosts: all
   gather_facts: false
   tasks:

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -32,6 +32,10 @@ docker_group_users: []
 # host setting unchanged unless the inventory explicitly requests it.
 docker_enable_ip_forward: false
 
+# Start/restart Docker via systemd. Disable in molecule docker-ci (nested
+# systemd container cannot reliably run docker.service on hosted runners).
+docker_manage_service: true
+
 # When Docker iptables is off on EL, discover IPv4 subnets (docker network inspect) and add
 # nftables masquerade per subnet (iptables MASQUERADE is unreliable on EL9+ nf_tables); re-run
 # after compose so project networks exist. Falls back to 172.16.0.0/12 if discovery is empty.

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Restart Docker
-  service:
+  ansible.builtin.service:
     name: docker
     state: restarted
     enabled: true
+  when: docker_manage_service | default(true) | bool


### PR DESCRIPTION
## Summary

Closes #187. Priority 7 (CI polish):

- **`molecule/docker-ci`** — docker-driver Molecule scenario (docker role smoke, no Vagrant)
- **CI job `molecule-docker-smoke`** — runs `molecule test -s docker-ci` on code-changing PRs
- **PR template** — HA/failover section with `molecule test -s ubuntu` checkbox

## Test plan

- [ ] CI green (including new Molecule docker driver smoke job)
- [ ] Existing Vagrant scenarios unchanged (`molecule/docker` local)


Made with [Cursor](https://cursor.com)