### PR TITLE
docs: document HA testing scope across CI, Molecule, and AWS

### DIFF
--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -150,6 +150,22 @@ Then `run.sh`:
 | `no-unbound` | `pihole.yml`, `no-unbound.yml` |
 | `ha` | Pi-hole, Unbound, keepalived, VIP DNS, Nebula Sync (not used by default AWS workflows) |
 
+### HA / scope
+
+The `ha` scenario exists in `tests/remote/run.sh` for manual experimentation, but
+**no default workflow** (scheduled, RC, or PR label) invokes it. Remote AWS tests
+today launch **one ephemeral EC2 instance** — bootstrap, verify, optional update,
+teardown.
+
+Dual-node AWS HA (two instances, VIP, keepalived failover) is **not planned** for
+scheduled or RC runs without an explicit product decision. Reasons: ~2× cost per
+run, scope creep versus the smoke-test goal, and HA verify/failover logic lives in
+Molecule (`molecule/common/verify_ha.yml`), not in the remote playbook set wired
+for CI.
+
+For full failover/failback coverage, use local `molecule test -s ubuntu`. See
+[Testing guide — HA testing scope](testing.md#ha-testing-scope).
+
 ---
 
 ## What `create-ephemeral-env.sh` does

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -150,21 +150,32 @@ Then `run.sh`:
 | `no-unbound` | `pihole.yml`, `no-unbound.yml` |
 | `ha` | Pi-hole, Unbound, keepalived, VIP DNS, Nebula Sync (not used by default AWS workflows) |
 
-### HA / scope
+### HA / scope — single-node only (dual-node declined)
 
-The `ha` scenario exists in `tests/remote/run.sh` for manual experimentation, but
-**no default workflow** (scheduled, RC, or PR label) invokes it. Remote AWS tests
-today launch **one ephemeral EC2 instance** — bootstrap, verify, optional update,
-teardown.
+Remote AWS tests launch **one ephemeral EC2 instance** per matrix row: bootstrap,
+verify, optional update, teardown. That is the intended scope for scheduled, RC,
+and PR-label runs.
 
-Dual-node AWS HA (two instances, VIP, keepalived failover) is **not planned** for
-scheduled or RC runs without an explicit product decision. Reasons: ~2× cost per
-run, scope creep versus the smoke-test goal, and HA verify/failover logic lives in
-Molecule (`molecule/common/verify_ha.yml`), not in the remote playbook set wired
-for CI.
+**Dual-node AWS HA is explicitly declined / out of scope.** The operational burden
+does not justify the incremental confidence over local Molecule:
 
-For full failover/failback coverage, use local `molecule test -s ubuntu`. See
-[Testing guide — HA testing scope](testing.md#ha-testing-scope).
+| Burden | Why it matters |
+|--------|----------------|
+| 2× EC2 per run | Doubles cost and runtime on every scheduled, RC, and label-triggered job |
+| VRRP security group | Keepalived needs multicast/VRRP between instances on a public subnet |
+| Private/public IP inventory | Dual-node keepalived requires per-node and VIP addressing in ephemeral inventory |
+| Porting failover verify | Molecule HA checks (`molecule/common/verify_ha.yml`) are not wired into remote verify playbooks |
+| Longer runs | Create, converge, verify, and destroy scale with two hosts |
+
+Local Molecule already exercises full failover and failback on same-subnet Vagrant
+boxes. AWS remote stays **single-node smoke**; full HA coverage is **local Molecule
+only** (`molecule test -s ubuntu`).
+
+The `ha` scenario in `tests/remote/run.sh` exists for ad-hoc manual experimentation
+only — **no default workflow** (scheduled, RC, or PR label) invokes it, and there
+is no plan to add dual-node AWS HA to CI.
+
+See [Testing guide — HA testing scope](testing.md#ha-testing-scope).
 
 ---
 

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -111,9 +111,9 @@ Local graphify setup is valuable; graph quality can be improved.
 
 | Layer | Runs today | Gap |
 |-------|------------|-----|
-| GitHub CI | Lint, syntax, check-mode bootstrap + update-pihole, compose validation | No functional HA or update path |
-| Molecule | 6 scenarios locally; HA verify on `ubuntu` | Not in CI; `update-pihole` in `ubuntu`, `ubuntu-26.04`, and `pihole-no-unbound` |
-| AWS remote | Bootstrap + optional `update-pihole` | Scheduled 1st/15th + PR label; manual dispatch for full matrix |
+| GitHub CI | Lint, syntax, check-mode bootstrap + update-pihole, compose validation, **`docker-ci` Molecule smoke** | No functional HA failover (local Molecule only) |
+| Molecule | 6 scenarios locally; full HA + update on `ubuntu` / `ubuntu-26.04` | HA not in GitHub CI — requires local Vagrant |
+| AWS remote | Single-node bootstrap + optional `update-pihole` | Scheduled 1st/15th + PR label; dual-node AWS HA out of scope |
 
 ## Suggested first issues
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -110,8 +110,26 @@ pattern on Ubuntu 26.04.
 | Layer | HA coverage | Why |
 |-------|-------------|-----|
 | **GitHub CI** | **No** — `molecule test -s docker-ci` smoke only | Hosted runners have no Vagrant; docker-ci exercises the docker role, not keepalived/VIP failover |
-| **AWS remote** | **No** — single-node bootstrap + verify + optional update today | Dual-node AWS HA is **explicitly out of scope**: ~2× EC2 cost per run, no scheduled/RC workflow wired for it, and remote verify playbooks are not ported for multi-node failover orchestration |
+| **AWS remote** | **No** — single-node smoke only | Dual-node AWS HA is **declined / out of scope** (see below) |
 | **Local Molecule** | **Yes** — full HA path | Only environment with same-subnet dual nodes and existing HA verify tasks |
+
+**Decision — dual-node AWS HA declined:** Running full HA failover in AWS remote tests is
+**not worth the operational burden** for the value it adds. Local Molecule already
+covers keepalived, VIP movement, and post-update HA verification; AWS remote tests
+remain **single-node smoke** (bootstrap → verify → optional update → teardown).
+
+This is an explicit **out-of-scope** choice, not a backlog item. Operational cost
+exceeds benefit:
+
+- **2× EC2** per run (primary + secondary) and longer wall-clock time
+- **VRRP security group** rules and cross-instance networking on a public subnet
+- **Private/public IP inventory** wiring for keepalived and Ansible groups
+- **Porting failover verify** — remote playbooks would need the Molecule HA verify
+  path (`molecule/common/verify_ha.yml`) adapted for ephemeral multi-host orchestration
+- **Higher AWS spend** on every scheduled, RC, and label-triggered run
+
+The `ha` scenario in `tests/remote/run.sh` remains for ad-hoc experimentation only;
+no scheduled, RC, or PR-label workflow will invoke dual-node AWS HA.
 
 **Gate for HA-touching PRs:** the PR template checkbox ("Ran `molecule test -s ubuntu`
 locally") remains the required attestation when changes touch keepalived, VIP

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,6 +93,35 @@ See [README — Molecule integration tests](../README.md#molecule-integration-te
 
 ---
 
+## HA testing scope
+
+Full **failover and failback** (keepalived, VIP movement, per-node DNS after
+primary outage) is validated only in the **local Molecule HA lab** — same-subnet
+Vagrant boxes where two nodes can share a virtual IP:
+
+```bash
+molecule test -s ubuntu
+```
+
+Shared verify logic (`molecule/common/verify_ha.yml`) exercises VIP DNS, keepalived
+state, and post-update HA checks. The `ubuntu-26.04` scenario follows the same
+pattern on Ubuntu 26.04.
+
+| Layer | HA coverage | Why |
+|-------|-------------|-----|
+| **GitHub CI** | **No** — `molecule test -s docker-ci` smoke only | Hosted runners have no Vagrant; docker-ci exercises the docker role, not keepalived/VIP failover |
+| **AWS remote** | **No** — single-node bootstrap + verify + optional update today | Dual-node AWS HA is **explicitly out of scope**: ~2× EC2 cost per run, no scheduled/RC workflow wired for it, and remote verify playbooks are not ported for multi-node failover orchestration |
+| **Local Molecule** | **Yes** — full HA path | Only environment with same-subnet dual nodes and existing HA verify tasks |
+
+**Gate for HA-touching PRs:** the PR template checkbox ("Ran `molecule test -s ubuntu`
+locally") remains the required attestation when changes touch keepalived, VIP
+failover, rolling updates, or HA verification. CI and AWS remote tests do not
+substitute for that run.
+
+See also: [Failover testing](failover-testing.md) (manual production checks).
+
+---
+
 ## AWS remote tests
 
 Two workflows share scripts under `tests/remote/`:


### PR DESCRIPTION
## Summary

- Add **HA testing scope** section to `docs/testing.md`: full failover/failback is local `molecule test -s ubuntu` only; GitHub CI runs `docker-ci` smoke (no Vagrant HA); AWS remote is single-node smoke with dual-node AWS HA explicitly out of scope.
- Add **HA / scope** note to `docs/aws-remote-tests-workflow.md`: `ha` scenario in `run.sh` is not wired into default workflows; not planned for scheduled/RC without explicit decision.
- Refresh quick-reference table in `docs/improvement-backlog.md` to reflect current coverage.

PR template checkbox remains the gate for HA-touching changes.

## Test plan

- [x] Docs-only change — CI docs-only fast path expected
- [ ] Review cross-links render correctly


Made with [Cursor](https://cursor.com)