### PR TITLE
fix: retire 2026.05.0 Trivy legacy scan and doc hygiene

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -117,11 +117,13 @@ Local graphify setup is valuable; graph quality can be improved.
 
 ## Suggested first issues
 
-1. `ubuntu` Molecule side_effect for `update-pihole` + post-update HA verify
+All items below shipped (see Priority 1–7 above). No open starter issues remain.
+
+1. ~~`ubuntu` Molecule side_effect for `update-pihole` + post-update HA verify~~ ([#153](https://github.com/steveyminecraft/ansible-pihole/issues/153))
 2. ~~Scheduled AWS remote test on `master` (twice monthly, amd64)~~ ([#155](https://github.com/steveyminecraft/ansible-pihole/issues/155))
-3. Runbook section for rolling updates / drain-resume
-4. Inventory pre-flight validator
-5. Upstream image check in CI
+3. ~~Runbook section for rolling updates / drain-resume~~ ([#161](https://github.com/steveyminecraft/ansible-pihole/issues/161))
+4. ~~Inventory pre-flight validator~~ ([#178](https://github.com/steveyminecraft/ansible-pihole/issues/178))
+5. ~~Upstream image check in CI~~ ([#181](https://github.com/steveyminecraft/ansible-pihole/issues/181))
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -185,5 +185,5 @@ python scripts/check-legacy-inventory-vars.py path/to/your-inventory.yml
 ## Related docs
 
 - [Production deployment](production-deployment.md) — inventory mapping, health gates
-- [Improvement backlog](improvement-backlog.md) — planned test gaps
+- [Improvement backlog](improvement-backlog.md) — shipped improvement history
 - [Knowledge vault](knowledge-vault.md) — architecture graph for agents

--- a/scripts/default-container-images.py
+++ b/scripts/default-container-images.py
@@ -18,7 +18,6 @@ ROOT = Path(__file__).resolve().parents[1]
 # categories here until the repository security state no longer reports them as
 # required for PR alert comparison.
 LEGACY_CODE_SCANNING_IMAGES = (
-    "pihole/pihole:2026.05.0",
     "pihole/pihole:2026.06.0",
 )
 

--- a/tests/unit/test_default_container_images.py
+++ b/tests/unit/test_default_container_images.py
@@ -57,7 +57,6 @@ class DefaultContainerImagesTests(unittest.TestCase):
         images = set(self.helper.code_scanning_images())
 
         self.assertTrue(set(self.helper.default_images()) <= images)
-        self.assertIn("pihole/pihole:2026.05.0", images)
         self.assertIn("pihole/pihole:2026.06.0", images)
 
     def test_image_key_preserves_image_tag_for_code_scanning_category(self) -> None:


### PR DESCRIPTION
## Summary

- Retire `pihole/pihole:2026.05.0` from Trivy code-scanning image categories; default pin is already `2026.07.2` (merged in #152). Keep `2026.06.0` for GitHub alert continuity per P4 workflow.
- Doc hygiene: mark all "Suggested first issues" as shipped in `docs/improvement-backlog.md`; fix stale "planned test gaps" link in `docs/testing.md`.

Closes #147 (stale upstream image alert — pin already at latest `2026.07.2`).

## Trivy context

Open code-scanning alerts were dominated by the retired `2026.05.0` scan category (29 alerts). One HIGH alert remains on the current `2026.07.2` image (`CVE-2026-33630` in `c-ares`) — upstream artifact; no newer calendar tag on Docker Hub yet.

## Test plan

- [x] `python3 -m unittest discover -s tests/unit`
- [x] `python3 scripts/check-pihole-image-pins.py`
- [x] `python3 scripts/check-pihole-image-upstream.py`
- [ ] CI Security scanning (Trivy image matrix should drop `2026.05.0` category)


Made with [Cursor](https://cursor.com)