### PR TITLE
feat: sync full documentation into Obsidian knowledge vault

### DIFF
--- a/docs/knowledge-vault.md
+++ b/docs/knowledge-vault.md
@@ -17,7 +17,8 @@ Agents and contributors use the graph for architecture questions; humans can bro
 
 Open the interactive map: `graphify-out/graph.html`  
 Open Obsidian vault: `graphify-out/obsidian/`  
-Browse full docs in vault: `00 - Documentation Index.md` → `Documentation/`
+Browse full docs in vault: `00 - Documentation Index.md` → `Documentation/`  
+Layers + CI map: `00 - Architecture and CI.md` (diagram embed + workflow links)
 
 ## What gets generated (all local)
 
@@ -30,6 +31,9 @@ Browse full docs in vault: `00 - Documentation Index.md` → `Documentation/`
 | `graphify-out/obsidian/` | Wikilinked graph notes + `graph.canvas` |
 | `graphify-out/obsidian/Documentation/` | Full-text copies of `docs/`, README, role READMEs (with graph links) |
 | `graphify-out/obsidian/00 - Documentation Index.md` | Index of all synced documentation |
+| `graphify-out/obsidian/00 - Architecture and CI.md` | Layer diagram + CI workflow map (links layers to docs and `.github/workflows/`) |
+| `graphify-out/obsidian/Documentation/diagrams/` | Layer diagram PNG + `.drawio` (when `docs/diagrams/` exists in repo) |
+| `graphify-out/obsidian/Documentation/ci-workflows/` | Full-text copies of GitHub Actions workflow YAML |
 
 ## Bootstrap modes
 

--- a/docs/knowledge-vault.md
+++ b/docs/knowledge-vault.md
@@ -16,7 +16,8 @@ Agents and contributors use the graph for architecture questions; humans can bro
 ```
 
 Open the interactive map: `graphify-out/graph.html`  
-Open Obsidian vault: `graphify-out/obsidian/`
+Open Obsidian vault: `graphify-out/obsidian/`  
+Browse full docs in vault: `00 - Documentation Index.md` → `Documentation/`
 
 ## What gets generated (all local)
 
@@ -26,7 +27,9 @@ Open Obsidian vault: `graphify-out/obsidian/`
 | `graphify-out/graph.html` | Browser visualization |
 | `graphify-out/GRAPH_REPORT.md` | God nodes, communities, surprising connections |
 | `graphify-out/KNOWLEDGE_VAULT.md` | Local entry point (copied from this doc + build stats) |
-| `graphify-out/obsidian/` | Wikilinked notes + `graph.canvas` |
+| `graphify-out/obsidian/` | Wikilinked graph notes + `graph.canvas` |
+| `graphify-out/obsidian/Documentation/` | Full-text copies of `docs/`, README, role READMEs (with graph links) |
+| `graphify-out/obsidian/00 - Documentation Index.md` | Index of all synced documentation |
 
 ## Bootstrap modes
 
@@ -68,7 +71,7 @@ graphify explain "molecule/default/molecule.yml"
 | Python/shell | `graphify update .` (automatic with post-commit hook) |
 | Roles, playbooks, docs | `/graphify .` or full rebuild |
 | After full rebuild | `python3 scripts/dedupe-graphify-graph.py --prune-isolated` |
-| Re-export Obsidian | `graphify export obsidian` |
+| Re-export Obsidian | `graphify export obsidian` then `python3 scripts/sync-obsidian-documentation.py` |
 | Re-export HTML | `graphify export html` |
 
 ### Post-commit hook

--- a/scripts/setup-knowledge-vault.sh
+++ b/scripts/setup-knowledge-vault.sh
@@ -67,6 +67,7 @@ write_local_index() {
 
   if [[ -d graphify-out/obsidian ]]; then
     cp graphify-out/KNOWLEDGE_VAULT.md "graphify-out/obsidian/00 - Knowledge Vault Index.md"
+    python3 "$ROOT/scripts/sync-obsidian-documentation.py"
   fi
 }
 
@@ -108,6 +109,8 @@ graphify export html
 if [[ -f graphify-out/graph.json ]]; then
   echo "Exporting Obsidian vault..."
   graphify export obsidian
+  echo "Syncing full documentation into Obsidian..."
+  python3 "$ROOT/scripts/sync-obsidian-documentation.py"
   write_local_index
 fi
 

--- a/scripts/sync-obsidian-documentation.py
+++ b/scripts/sync-obsidian-documentation.py
@@ -5,7 +5,82 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
+
+DIAGRAM_ASSETS = ("ansible-pihole-layers.png", "ansible-pihole-layers.drawio")
+
+LAYER_GUIDE: list[tuple[str, str, list[str]]] = [
+    (
+        "1 · Development & CI",
+        "Entry points: operator runs, GitHub Actions, Molecule, AWS remote tests, scripts, docs, unit tests.",
+        [
+            "Documentation/testing",
+            "Documentation/ci-workflows/ci",
+            "Documentation/ci-workflows/aws-remote-tests",
+            "Documentation/ci-workflows/security",
+            "Documentation/ci-workflows/galaxy-publish",
+            "Documentation/ci-workflows/release-please",
+        ],
+    ),
+    (
+        "2 · Playbooks",
+        "Orchestration playbooks: bootstrap, rolling update, keepalived, sync, CI helpers.",
+        [
+            "Documentation/architecture",
+            "Documentation/upgrade-runbook",
+            "Documentation/production-deployment",
+        ],
+    ),
+    (
+        "3 · Ansible roles",
+        "Collection roles: bootstrap → updates → sshd → keepalived → docker → unbound → pihole (+ nebula_sync).",
+        [
+            "Documentation/knowledge-vault",
+            "Documentation/roles/docker/README",
+            "Documentation/roles/keepalived/README",
+            "Documentation/roles/pihole/README",
+            "Documentation/roles/nebula_sync/README",
+        ],
+    ),
+    (
+        "4 · Inventory & variables",
+        "Production, lab, CI, and remote-test inventories; group_vars and host patterns.",
+        [
+            "Documentation/production-deployment",
+            "Documentation/tests/remote/README",
+        ],
+    ),
+    (
+        "5 · Verification",
+        "Molecule scenarios (docker-ci smoke, Vagrant HA), remote verify playbooks, failover tests.",
+        [
+            "Documentation/testing",
+            "Documentation/failover-testing",
+            "Documentation/aws-remote-tests-workflow",
+        ],
+    ),
+    (
+        "6 · Runtime stack",
+        "Docker-hosted Pi-hole (+ optional Unbound), Keepalived VIP, Nebula Sync replication.",
+        [
+            "Documentation/architecture",
+            "Documentation/backup-and-restore",
+            "Documentation/secrets-management",
+        ],
+    ),
+]
+
+CI_WORKFLOW_FILES = (
+    "ci.yml",
+    "security.yml",
+    "galaxy-publish.yml",
+    "release-please.yml",
+    "auto-run-release-please-checks.yml",
+    "aws-remote-tests.yml",
+    "rc-aws-remote-tests.yml",
+    "pihole-image-watch.yml",
+)
 
 
 def load_graph_labels(graph_path: Path) -> dict[str, list[str]]:
@@ -33,7 +108,7 @@ def vault_link(dest: Path, obsidian_dir: Path) -> str:
     return f"[[{rel.as_posix()}]]"
 
 
-def frontmatter(rel_path: str, labels: list[str]) -> str:
+def frontmatter(rel_path: str, labels: list[str], *, extra_tags: list[str] | None = None) -> str:
     lines = [
         "---",
         f'source_file: "{rel_path}"',
@@ -41,6 +116,8 @@ def frontmatter(rel_path: str, labels: list[str]) -> str:
         "  - documentation",
         "  - graphify/source",
     ]
+    for tag in extra_tags or []:
+        lines.append(f"  - {tag}")
     if labels:
         lines.append("graph_connections:")
         for label in labels:
@@ -62,19 +139,152 @@ def sync_file(
     dest: Path,
     rel_path: str,
     labels_by_source: dict[str, list[str]],
+    *,
+    extra_tags: list[str] | None = None,
 ) -> tuple[str, Path, list[str]]:
     labels = labels_by_source.get(rel_path, [])
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(
-        frontmatter(rel_path, labels) + graph_banner(labels) + source.read_text(encoding="utf-8"),
+        frontmatter(rel_path, labels, extra_tags=extra_tags)
+        + graph_banner(labels)
+        + source.read_text(encoding="utf-8"),
         encoding="utf-8",
     )
     return rel_path, dest, labels
 
 
+def sync_ci_workflow(
+    source: Path,
+    dest: Path,
+    rel_path: str,
+    labels_by_source: dict[str, list[str]],
+) -> tuple[str, Path, list[str]]:
+    labels = labels_by_source.get(rel_path, [])
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    body = source.read_text(encoding="utf-8")
+    dest.write_text(
+        frontmatter(rel_path, labels, extra_tags=["ci-workflow"])
+        + graph_banner(labels)
+        + f"# {source.stem}\n\n"
+        + f"Repository path: `{rel_path}`\n\n"
+        + "```yaml\n"
+        + body
+        + "\n```\n",
+        encoding="utf-8",
+    )
+    return rel_path, dest, labels
+
+
+def sync_diagram_assets(repo_root: Path, obsidian_dir: Path) -> list[str]:
+    copied: list[str] = []
+    src_dir = repo_root / "docs" / "diagrams"
+    if not src_dir.is_dir():
+        return copied
+    dest_dir = obsidian_dir / "Documentation" / "diagrams"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for name in DIAGRAM_ASSETS:
+        src = src_dir / name
+        if src.is_file():
+            shutil.copy2(src, dest_dir / name)
+            copied.append(name)
+    return copied
+
+
+def build_architecture_ci_hub(
+    obsidian_dir: Path,
+    labels_by_source: dict[str, list[str]],
+    diagram_assets: list[str],
+) -> None:
+    diagram_links = labels_by_source.get("docs/diagrams/ansible-pihole-layers.png", [])
+    ci_labels = labels_by_source.get(".github/workflows/ci.yml", [])
+
+    lines = [
+        "---",
+        "tags:",
+        "  - documentation",
+        "  - graphify/index",
+        "  - architecture",
+        "  - ci-workflow",
+        "---",
+        "",
+        "# Architecture & CI",
+        "",
+        "Map of **project layers** (playbooks → roles → runtime) alongside the **GitHub CI workflow** surface.",
+        "",
+        "Vault hub: [[00 - Knowledge Vault Index]] · Docs index: [[00 - Documentation Index]]",
+        "",
+    ]
+
+    if diagram_links:
+        lines.append("> **Graph:** " + " · ".join(wikilink(label) for label in diagram_links[:4]) + "\n")
+
+    if "ansible-pihole-layers.png" in diagram_assets:
+        lines.extend(
+            [
+                "## Project layers (diagram)",
+                "",
+                "![[Documentation/diagrams/ansible-pihole-layers.png]]",
+                "",
+                "Editable source: [[Documentation/diagrams/ansible-pihole-layers.drawio]]",
+                "",
+                "Maintain with the draw.io skill (`.cursor/skills/drawio-skill/`) after PR #194 lands.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "## Project layers (diagram)",
+                "",
+                "_Diagram assets not synced yet — add `docs/diagrams/ansible-pihole-layers.{png,drawio}` "
+                "(see PR #194) and re-run `python3 scripts/sync-obsidian-documentation.py`._",
+                "",
+            ]
+        )
+
+    lines.extend(["## Layers → vault notes", ""])
+    for title, summary, vault_paths in LAYER_GUIDE:
+        links = " · ".join(f"[[{path}]]" for path in vault_paths)
+        lines.append(f"### {title}")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+        lines.append(links)
+        lines.append("")
+
+    lines.extend(["## CI workflows", ""])
+    if ci_labels:
+        lines.append("> **Graph:** " + " · ".join(wikilink(label) for label in ci_labels[:5]) + "\n")
+    lines.append("| Workflow | Vault note |")
+    lines.append("|----------|------------|")
+    for name in CI_WORKFLOW_FILES:
+        stem = Path(name).stem
+        rel = f".github/workflows/{name}"
+        lines.append(f"| `{name}` | [[Documentation/ci-workflows/{stem}]] |")
+    lines.extend(
+        [
+            "",
+            "## Related graph communities",
+            "",
+            "- [[_COMMUNITY_Architecture & Docs]]",
+            "- [[_COMMUNITY_CI & Release Workflow]]",
+            "- [[_COMMUNITY_Pi-hole HA Stack]]",
+            "",
+            "## Draw.io skill",
+            "",
+            "Regenerate or extend the layer diagram with [[Draw.io Diagram Skill]] (graph node) or "
+            "`.cursor/skills/drawio-skill/SKILL.md` in the repo.",
+            "",
+            "#architecture #ci-workflow #graphify/index",
+        ]
+    )
+    (obsidian_dir / "00 - Architecture and CI.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def build_index(
     entries: list[tuple[str, Path, list[str]]],
     obsidian_dir: Path,
+    diagram_assets: list[str],
 ) -> None:
     lines = [
         "---",
@@ -89,9 +299,17 @@ def build_index(
         "",
         "Vault hub: [[00 - Knowledge Vault Index]]",
         "",
-        "## All documentation",
+        "**Start here for layers + CI:** [[00 - Architecture and CI]]",
         "",
     ]
+    if diagram_assets:
+        lines.append(
+            "Layer diagram: [[Documentation/diagrams/ansible-pihole-layers.png]] "
+            "(source: [[Documentation/diagrams/ansible-pihole-layers.drawio]])"
+        )
+        lines.append("")
+
+    lines.extend(["## All documentation", ""])
     for rel_path, dest, labels in sorted(entries, key=lambda item: item[0]):
         graph = ""
         if labels:
@@ -143,7 +361,17 @@ def sync_documentation(
         dest = obsidian_dir / "Documentation" / "tests" / "remote" / "README.md"
         entries.append(sync_file(remote, dest, rel, labels_by_source))
 
-    build_index(entries, obsidian_dir)
+    for workflow in CI_WORKFLOW_FILES:
+        src = repo_root / ".github" / "workflows" / workflow
+        if not src.is_file():
+            continue
+        rel = str(src.relative_to(repo_root)).replace("\\", "/")
+        dest = obsidian_dir / "Documentation" / "ci-workflows" / f"{src.stem}.md"
+        entries.append(sync_ci_workflow(src, dest, rel, labels_by_source))
+
+    diagram_assets = sync_diagram_assets(repo_root, obsidian_dir)
+    build_architecture_ci_hub(obsidian_dir, labels_by_source, diagram_assets)
+    build_index(entries, obsidian_dir, diagram_assets)
     return len(entries)
 
 
@@ -165,6 +393,7 @@ def main() -> int:
 
     count = sync_documentation(repo_root, obsidian_dir, graph_path)
     print(f"Synced {count} documentation files to {obsidian_dir / 'Documentation'}/")
+    print(f"Hub: {obsidian_dir / '00 - Architecture and CI.md'}")
     print(f"Index: {obsidian_dir / '00 - Documentation Index.md'}")
     return 0
 

--- a/scripts/sync-obsidian-documentation.py
+++ b/scripts/sync-obsidian-documentation.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Copy repository documentation into the local Obsidian vault with graph links."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_graph_labels(graph_path: Path) -> dict[str, list[str]]:
+    if not graph_path.is_file():
+        return {}
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    labels_by_source: dict[str, list[str]] = {}
+    for node in graph.get("nodes", []):
+        source = (node.get("source_file") or node.get("path") or "").replace("\\", "/")
+        label = (node.get("label") or "").strip()
+        if not source or not label:
+            continue
+        labels_by_source.setdefault(source, [])
+        if label not in labels_by_source[source]:
+            labels_by_source[source].append(label)
+    return labels_by_source
+
+
+def wikilink(label: str) -> str:
+    return f"[[{label.replace(']]', '')}]]"
+
+
+def vault_link(dest: Path, obsidian_dir: Path) -> str:
+    rel = dest.relative_to(obsidian_dir).with_suffix("")
+    return f"[[{rel.as_posix()}]]"
+
+
+def frontmatter(rel_path: str, labels: list[str]) -> str:
+    lines = [
+        "---",
+        f'source_file: "{rel_path}"',
+        "tags:",
+        "  - documentation",
+        "  - graphify/source",
+    ]
+    if labels:
+        lines.append("graph_connections:")
+        for label in labels:
+            lines.append(f'  - "{label}"')
+    lines.extend(["---", ""])
+    return "\n".join(lines)
+
+
+def graph_banner(labels: list[str]) -> str:
+    if not labels:
+        return ""
+    links = " · ".join(wikilink(label) for label in labels[:6])
+    more = f" (+{len(labels) - 6} more)" if len(labels) > 6 else ""
+    return f"> **Graph connections:** {links}{more}\n\n"
+
+
+def sync_file(
+    source: Path,
+    dest: Path,
+    rel_path: str,
+    labels_by_source: dict[str, list[str]],
+) -> tuple[str, Path, list[str]]:
+    labels = labels_by_source.get(rel_path, [])
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(
+        frontmatter(rel_path, labels) + graph_banner(labels) + source.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return rel_path, dest, labels
+
+
+def build_index(
+    entries: list[tuple[str, Path, list[str]]],
+    obsidian_dir: Path,
+) -> None:
+    lines = [
+        "---",
+        "tags:",
+        "  - documentation",
+        "  - graphify/index",
+        "---",
+        "",
+        "# Documentation",
+        "",
+        "Full-text copies of repository docs, linked to graphify concept notes.",
+        "",
+        "Vault hub: [[00 - Knowledge Vault Index]]",
+        "",
+        "## All documentation",
+        "",
+    ]
+    for rel_path, dest, labels in sorted(entries, key=lambda item: item[0]):
+        graph = ""
+        if labels:
+            graph = " — " + ", ".join(wikilink(label) for label in labels[:3])
+        lines.append(f"- `{rel_path}` → {vault_link(dest, obsidian_dir)}{graph}")
+
+    lines.extend(
+        [
+            "",
+            "## Graph communities",
+            "",
+            "- [[_COMMUNITY_Architecture & Docs]]",
+            "- [[_COMMUNITY_CI & Release Workflow]]",
+            "- [[_COMMUNITY_HA Failover Testing]]",
+            "",
+            "#documentation #graphify/index",
+        ]
+    )
+    (obsidian_dir / "00 - Documentation Index.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def sync_documentation(
+    repo_root: Path,
+    obsidian_dir: Path,
+    graph_path: Path | None = None,
+) -> int:
+    labels_by_source = load_graph_labels(graph_path or obsidian_dir.parent / "graph.json")
+    entries: list[tuple[str, Path, list[str]]] = []
+
+    for src in sorted((repo_root / "docs").glob("**/*.md")):
+        rel = str(src.relative_to(repo_root)).replace("\\", "/")
+        dest = obsidian_dir / "Documentation" / src.relative_to(repo_root / "docs")
+        entries.append(sync_file(src, dest, rel, labels_by_source))
+
+    for name in ("README.md", "CONTRIBUTING.md", "CHANGELOG.md"):
+        src = repo_root / name
+        if src.is_file():
+            entries.append(sync_file(src, obsidian_dir / "Documentation" / name, name, labels_by_source))
+
+    for readme in sorted(repo_root.glob("roles/*/README.md")):
+        role = readme.parent.name
+        rel = str(readme.relative_to(repo_root)).replace("\\", "/")
+        dest = obsidian_dir / "Documentation" / "roles" / role / "README.md"
+        entries.append(sync_file(readme, dest, rel, labels_by_source))
+
+    remote = repo_root / "tests" / "remote" / "README.md"
+    if remote.is_file():
+        rel = "tests/remote/README.md"
+        dest = obsidian_dir / "Documentation" / "tests" / "remote" / "README.md"
+        entries.append(sync_file(remote, dest, rel, labels_by_source))
+
+    build_index(entries, obsidian_dir)
+    return len(entries)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--obsidian-dir", type=Path, default=None)
+    parser.add_argument("--graph", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    obsidian_dir = (args.obsidian_dir or repo_root / "graphify-out" / "obsidian").resolve()
+    graph_path = (args.graph or repo_root / "graphify-out" / "graph.json").resolve()
+
+    if not obsidian_dir.is_dir():
+        print(f"Obsidian vault not found: {obsidian_dir}")
+        print("Run: graphify export obsidian")
+        return 1
+
+    count = sync_documentation(repo_root, obsidian_dir, graph_path)
+    print(f"Synced {count} documentation files to {obsidian_dir / 'Documentation'}/")
+    print(f"Index: {obsidian_dir / '00 - Documentation Index.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_sync_obsidian_documentation.py
+++ b/tests/unit/test_sync_obsidian_documentation.py
@@ -1,0 +1,62 @@
+"""Unit tests for scripts/sync-obsidian-documentation.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "sync-obsidian-documentation.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("sync_obsidian_documentation", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SyncObsidianDocumentationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = load_module()
+
+    def test_sync_writes_full_doc_with_graph_banner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            obsidian = Path(tmp) / "graphify-out" / "obsidian"
+            docs = root / "docs"
+            docs.mkdir(parents=True)
+            (docs / "testing.md").write_text("# Testing\n\nBody text.\n", encoding="utf-8")
+            obsidian.mkdir(parents=True)
+            graph = {
+                "nodes": [
+                    {
+                        "label": "Testing Guide",
+                        "source_file": "docs/testing.md",
+                    }
+                ],
+                "links": [],
+            }
+            (obsidian.parent / "graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+            count = self.mod.sync_documentation(root, obsidian)
+            self.assertEqual(count, 1)
+
+            out = obsidian / "Documentation" / "testing.md"
+            self.assertTrue(out.is_file())
+            text = out.read_text(encoding="utf-8")
+            self.assertIn("source_file: \"docs/testing.md\"", text)
+            self.assertIn("[[Testing Guide]]", text)
+            self.assertIn("# Testing", text)
+            self.assertIn("Body text.", text)
+            self.assertTrue((obsidian / "00 - Documentation Index.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_sync_obsidian_documentation.py
+++ b/tests/unit/test_sync_obsidian_documentation.py
@@ -56,6 +56,41 @@ class SyncObsidianDocumentationTests(unittest.TestCase):
             self.assertIn("# Testing", text)
             self.assertIn("Body text.", text)
             self.assertTrue((obsidian / "00 - Documentation Index.md").is_file())
+            self.assertTrue((obsidian / "00 - Architecture and CI.md").is_file())
+
+    def test_sync_ci_workflow_and_diagram_hub(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            obsidian = Path(tmp) / "graphify-out" / "obsidian"
+            (root / "docs").mkdir(parents=True)
+            (root / "docs" / "architecture.md").write_text("# Architecture\n", encoding="utf-8")
+            (root / ".github" / "workflows").mkdir(parents=True)
+            (root / ".github" / "workflows" / "ci.yml").write_text("name: CI\n", encoding="utf-8")
+            (root / "docs" / "diagrams").mkdir(parents=True)
+            (root / "docs" / "diagrams" / "ansible-pihole-layers.png").write_bytes(b"png")
+            (root / "docs" / "diagrams" / "ansible-pihole-layers.drawio").write_text("<mxfile/>", encoding="utf-8")
+            obsidian.mkdir(parents=True)
+            graph = {
+                "nodes": [
+                    {"label": "CI Pipeline", "source_file": ".github/workflows/ci.yml"},
+                    {"label": "Six-Layer Architecture", "source_file": "docs/diagrams/ansible-pihole-layers.png"},
+                ],
+                "links": [],
+            }
+            (obsidian.parent / "graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+            count = self.mod.sync_documentation(root, obsidian)
+            self.assertGreaterEqual(count, 2)
+
+            ci_note = obsidian / "Documentation" / "ci-workflows" / "ci.md"
+            self.assertTrue(ci_note.is_file())
+            self.assertIn("ci-workflow", ci_note.read_text(encoding="utf-8"))
+            self.assertTrue((obsidian / "Documentation" / "diagrams" / "ansible-pihole-layers.png").is_file())
+
+            hub = (obsidian / "00 - Architecture and CI.md").read_text(encoding="utf-8")
+            self.assertIn("![[Documentation/diagrams/ansible-pihole-layers.png]]", hub)
+            self.assertIn("[[Documentation/ci-workflows/ci]]", hub)
+            self.assertIn("[[CI Pipeline]]", hub)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #191

## Summary

- Add `scripts/sync-obsidian-documentation.py` to copy `docs/`, README, CONTRIBUTING, CHANGELOG, role READMEs, and remote test docs into `graphify-out/obsidian/Documentation/` with graph cross-links
- Run the sync automatically from `setup-knowledge-vault.sh` after `graphify export obsidian`
- Document the `Documentation/` folder and index in `docs/knowledge-vault.md`
- Add unit test for doc sync with graph connection banner

## Release notes

- Proposed release note sentence:
  - N/A (local developer tooling only; `graphify-out/` remains gitignored)
- Changelog type:
  - [ ] `feat`
  - [ ] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-lint / yamllint (or N/A)
- [x] syntax checks for changed playbooks/roles (or N/A)
- [x] Molecule / remote tests when behavior changes (or N/A)
- [x] README / docs updated when needed

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit

Made with [Cursor](https://cursor.com)