### PR TITLE
fix(ci): move AWS test infra config to repository secrets

### DIFF
--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -77,7 +77,7 @@ jobs:
           INPUT_SCENARIO: ${{ github.event.inputs.scenario }}
           INPUT_SKIP_UPDATE: ${{ github.event.inputs.skip_update }}
           INPUT_AWS_REGION: ${{ github.event.inputs.aws_region }}
-          DEFAULT_AWS_REGION: ${{ vars.AWS_TEST_REGION }}
+          DEFAULT_AWS_REGION: ${{ secrets.AWS_TEST_REGION }}
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
@@ -135,7 +135,7 @@ jobs:
       AWS_OS_FAMILY: ${{ matrix.os_family }}
       AWS_OS_VERSION: ${{ matrix.os_version }}
       AWS_ARCH: ${{ matrix.arch }}
-      AWS_SUBNET_ID: ${{ vars.AWS_TEST_SUBNET_ID }}
+      AWS_SUBNET_ID: ${{ secrets.AWS_TEST_SUBNET_ID }}
       AWS_KEY_NAME: ${{ vars.AWS_TEST_KEY_NAME }}
       AWS_SSH_CIDR: ${{ vars.AWS_TEST_SSH_CIDR }}
       AWS_INSTANCE_TYPE: ${{ matrix.arch == 'arm64' && vars.AWS_TEST_INSTANCE_TYPE_ARM64 || vars.AWS_TEST_INSTANCE_TYPE_AMD64 }}
@@ -164,8 +164,8 @@ jobs:
               missing=1
             fi
           done
-          if [ -z "${{ vars.AWS_TEST_ROLE_ARN }}" ]; then
-            echo "Missing required variable: AWS_TEST_ROLE_ARN"
+          if [ -z "${{ secrets.AWS_TEST_ROLE_ARN }}" ]; then
+            echo "Missing required secret: AWS_TEST_ROLE_ARN"
             missing=1
           fi
           if [ -z "${PIHOLE_API_PASSWORD:-}" ]; then
@@ -188,7 +188,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v4
         with:
-          role-to-assume: ${{ vars.AWS_TEST_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: ansible-pihole-aws-tests
 

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:
-      AWS_REGION: ${{ vars.AWS_TEST_REGION }}
+      AWS_REGION: ${{ secrets.AWS_TEST_REGION }}
       AWS_TEST_SCENARIO: ${{ github.event.inputs.scenario || 'pihole-unbound' }}
       AWS_OS_FAMILY: ubuntu
       AWS_OS_VERSION: "26.04"
       AWS_ARCH: amd64
-      AWS_SUBNET_ID: ${{ vars.AWS_TEST_SUBNET_ID }}
+      AWS_SUBNET_ID: ${{ secrets.AWS_TEST_SUBNET_ID }}
       AWS_KEY_NAME: ${{ vars.AWS_TEST_KEY_NAME }}
       AWS_SSH_CIDR: ${{ vars.AWS_TEST_SSH_CIDR || '0.0.0.0/0' }}
       AWS_INSTANCE_TYPE: ${{ vars.AWS_TEST_INSTANCE_TYPE_AMD64 }}
@@ -63,8 +63,8 @@ jobs:
               missing=1
             fi
           done
-          if [ -z "${{ vars.AWS_TEST_ROLE_ARN }}" ]; then
-            echo "Missing required variable: AWS_TEST_ROLE_ARN"
+          if [ -z "${{ secrets.AWS_TEST_ROLE_ARN }}" ]; then
+            echo "Missing required secret: AWS_TEST_ROLE_ARN"
             missing=1
           fi
           if [ -z "${PIHOLE_API_PASSWORD:-}" ]; then
@@ -85,7 +85,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v4
         with:
-          role-to-assume: ${{ vars.AWS_TEST_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: ansible-pihole-rc-ubuntu-26.04
 

--- a/docs/aws-remote-tests-auth.md
+++ b/docs/aws-remote-tests-auth.md
@@ -40,11 +40,11 @@ Then:
 ```yaml
 - uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4
   with:
-    role-to-assume: ${{ vars.AWS_TEST_ROLE_ARN }}
+    role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
     aws-region: ${{ env.AWS_REGION }}
 ```
 
-`AWS_TEST_ROLE_ARN` is a repository variable, typically:
+`AWS_TEST_ROLE_ARN` is a repository secret, typically:
 
 ```text
 arn:aws:iam::290488660479:role/build-ci-github-build
@@ -146,9 +146,9 @@ Other permissions on the same role (artifacts S3, Secrets Manager under `/build/
 
 | Item | Type | Role |
 |---|---|---|
-| `AWS_TEST_ROLE_ARN` | Variable | Which IAM role OIDC should assume |
-| `AWS_TEST_REGION` | Variable | AWS region for EC2 and STS |
-| `AWS_TEST_SUBNET_ID` | Variable | Subnet for ephemeral hosts |
+| `AWS_TEST_ROLE_ARN` | Secret | Which IAM role OIDC should assume |
+| `AWS_TEST_REGION` | Secret | AWS region for EC2 and STS |
+| `AWS_TEST_SUBNET_ID` | Secret | Subnet for ephemeral hosts |
 | `AWS_TEST_KEY_NAME` | Variable | EC2 key pair name |
 | `AWS_TEST_INSTANCE_TYPE_AMD64` / `_ARM64` | Variable | Instance size per architecture |
 | `AWS_TEST_SSH_PRIVATE_KEY` | Secret | Private half of the EC2 key pair |

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -68,7 +68,7 @@ the PR head commit. Re-runs on new pushes while the label remains.
 | `platform_coverage` | `one-arch` or `all-archs` |
 | `arch` | For `one-arch` only: `amd64` or `arm64` |
 | `skip_update` | Skip the update playbook |
-| `aws_region` | Optional override; defaults to `AWS_TEST_REGION` repo variable |
+| `aws_region` | Optional override; defaults to `AWS_TEST_REGION` repository secret |
 
 ### 2. Permissions and concurrency
 
@@ -99,11 +99,11 @@ Runs once per matrix row (in parallel when `full`).
 
 **Environment variables** wire GitHub configuration to the scripts:
 
-| Variable | Source | Purpose |
+| Name | Source | Purpose |
 |---|---|---|
-| `AWS_TEST_ROLE_ARN` | repo variable | OIDC role in build-ci |
-| `AWS_TEST_REGION` | repo variable | e.g. `eu-west-1` |
-| `AWS_TEST_SUBNET_ID` | repo variable | Public ephemeral subnet |
+| `AWS_TEST_ROLE_ARN` | repo secret | OIDC role in build-ci |
+| `AWS_TEST_REGION` | repo secret | e.g. `eu-west-1` |
+| `AWS_TEST_SUBNET_ID` | repo secret | Public ephemeral subnet |
 | `AWS_TEST_KEY_NAME` | repo variable | EC2 key pair name |
 | `AWS_TEST_INSTANCE_TYPE_*` | repo variable | e.g. `t3.small` |
 | `AWS_TEST_SSH_PRIVATE_KEY` | repo secret | SSH to the new host |

--- a/tests/remote/README.md
+++ b/tests/remote/README.md
@@ -68,9 +68,6 @@ Pi-hole image updates are tracked separately by
 
 Repository variables:
 
-- `AWS_TEST_ROLE_ARN`
-- `AWS_TEST_REGION`
-- `AWS_TEST_SUBNET_ID`
 - `AWS_TEST_KEY_NAME`
 - `AWS_TEST_INSTANCE_TYPE_AMD64`
 - `AWS_TEST_INSTANCE_TYPE_ARM64`
@@ -78,6 +75,9 @@ Repository variables:
 
 Repository secrets:
 
+- `AWS_TEST_ROLE_ARN`
+- `AWS_TEST_REGION`
+- `AWS_TEST_SUBNET_ID`
 - `AWS_TEST_SSH_PRIVATE_KEY`
 - `AWS_TEST_PIHOLE_API_PASSWORD`
 - optional `AWS_TEST_ANSIBLE_VAULT_PASSWORD`
@@ -90,11 +90,16 @@ static AWS API keys.
 Remote test networking and GitHub OIDC access live in the **`AWS-Cloud`**
 repository under `build-account-isolation/build/`. After `terraform apply`,
 map `terraform output -json ansible_remote_test_configuration` to repository
-variables:
+configuration:
+
+Secrets:
 
 - `AWS_TEST_ROLE_ARN`
 - `AWS_TEST_REGION`
 - `AWS_TEST_SUBNET_ID`
+
+Variables:
+
 - `AWS_TEST_KEY_NAME`
 - `AWS_TEST_INSTANCE_TYPE_AMD64`
 

--- a/tests/unit/test_aws_remote_workflow_secrets.py
+++ b/tests/unit/test_aws_remote_workflow_secrets.py
@@ -1,0 +1,40 @@
+"""Guard AWS remote workflow configuration for infra secrets."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "aws-remote-tests.yml",
+    REPO_ROOT / ".github" / "workflows" / "rc-aws-remote-tests.yml",
+)
+
+INFRA_SECRETS = (
+    "AWS_TEST_REGION",
+    "AWS_TEST_ROLE_ARN",
+    "AWS_TEST_SUBNET_ID",
+)
+
+
+class AwsRemoteWorkflowSecretsTests(unittest.TestCase):
+    def test_infra_config_uses_repository_secrets_not_variables(self) -> None:
+        for workflow in WORKFLOWS:
+            text = workflow.read_text(encoding="utf-8")
+            with self.subTest(workflow=workflow.name):
+                for name in INFRA_SECRETS:
+                    self.assertIn(
+                        f"secrets.{name}",
+                        text,
+                        f"{workflow.name} should reference secrets.{name}",
+                    )
+                    self.assertNotIn(
+                        f"vars.{name}",
+                        text,
+                        f"{workflow.name} must not reference vars.{name}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #195

## Summary

- Switch `AWS_TEST_REGION`, `AWS_TEST_ROLE_ARN`, and `AWS_TEST_SUBNET_ID` from `vars.*` to `secrets.*` in `aws-remote-tests.yml` and `rc-aws-remote-tests.yml`
- Update remote-test documentation (`docs/aws-remote-tests-*.md`, `tests/remote/README.md`)
- Add `tests/unit/test_aws_remote_workflow_secrets.py` to guard against reverting to repository variables

## Operator action required (before/after merge)

In GitHub → **Settings → Secrets and variables → Actions**:

1. Create repository **secrets** (if not already present):
   - `AWS_TEST_REGION`
   - `AWS_TEST_ROLE_ARN`
   - `AWS_TEST_SUBNET_ID`
2. Copy values from the existing repository **variables** with the same names
3. Delete the old repository **variables** once workflows are green

Until secrets exist, scheduled/label AWS remote test runs will fail the config validation step.

## Release notes

- Proposed release note sentence:
  - N/A (CI configuration only)
- Changelog type:
  - [ ] `feat`
  - [x] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [ ] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-lint / yamllint (or N/A)
- [x] syntax checks for changed playbooks/roles (or N/A)
- [x] Molecule / remote tests when behavior changes (or N/A)
- [x] README / docs updated when needed
- [x] `python3 -m unittest tests.unit.test_aws_remote_workflow_secrets`

## Scope and risk

- Risk level: [ ] low  [x] medium  [ ] high
- Rollback plan: revert PR and restore repository variables; or re-add variables with same values while reverting workflow references

Made with [Cursor](https://cursor.com)