### PR TITLE
fix(ci): stop passing AWS region through job outputs

### DIFF
--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -66,7 +66,6 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       scenario: ${{ steps.matrix.outputs.scenario }}
       skip_update: ${{ steps.matrix.outputs.skip_update }}
-      aws_region: ${{ steps.matrix.outputs.aws_region }}
     steps:
       - name: Resolve matrix
         id: matrix
@@ -76,8 +75,6 @@ jobs:
           INPUT_ARCH: ${{ github.event.inputs.arch }}
           INPUT_SCENARIO: ${{ github.event.inputs.scenario }}
           INPUT_SKIP_UPDATE: ${{ github.event.inputs.skip_update }}
-          INPUT_AWS_REGION: ${{ github.event.inputs.aws_region }}
-          DEFAULT_AWS_REGION: ${{ secrets.AWS_TEST_REGION }}
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
@@ -109,15 +106,9 @@ jobs:
                   "arch": (os.environ.get("INPUT_ARCH") or "amd64").strip(),
               }]
 
-          region = (
-              (os.environ.get("INPUT_AWS_REGION") or "").strip()
-              or (os.environ.get("DEFAULT_AWS_REGION") or "").strip()
-          )
-
           print(f"matrix={json.dumps({'include': matrix})}")
           print(f"scenario={scenario}")
           print(f"skip_update={skip_update}")
-          print(f"aws_region={region}")
           PY
 
   aws-remote-tests:
@@ -129,7 +120,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
     env:
-      AWS_REGION: ${{ needs.prepare-matrix.outputs.aws_region }}
+      # Resolve region in this job. Do not pass secrets.AWS_TEST_REGION through
+      # prepare-matrix outputs — Actions redacts secret-bearing job outputs to empty.
+      AWS_REGION: ${{ github.event.inputs.aws_region || secrets.AWS_TEST_REGION }}
       AWS_TEST_SCENARIO: ${{ needs.prepare-matrix.outputs.scenario }}
       AWS_SKIP_UPDATE: ${{ needs.prepare-matrix.outputs.skip_update }}
       AWS_OS_FAMILY: ${{ matrix.os_family }}
@@ -230,11 +223,21 @@ jobs:
 
       - name: Ensure cleanup executes on failures
         if: always()
-        run: tests/remote/aws/destroy-ephemeral-env.sh
+        run: |
+          if [ ! -f tests/remote/aws/destroy-ephemeral-env.sh ]; then
+            echo "Repository checkout did not run; skipping destroy."
+            exit 0
+          fi
+          tests/remote/aws/destroy-ephemeral-env.sh
 
       - name: Verify AWS cleanup status
         if: always()
-        run: tests/remote/aws/verify-cleanup.sh
+        run: |
+          if [ ! -f tests/remote/aws/verify-cleanup.sh ]; then
+            echo "Repository checkout did not run; skipping cleanup verification."
+            exit 0
+          fi
+          tests/remote/aws/verify-cleanup.sh
 
       - name: Publish AWS test summary
         if: always()

--- a/docs/aws-remote-tests-workflow.md
+++ b/docs/aws-remote-tests-workflow.md
@@ -91,7 +91,7 @@ This job turns your manual inputs into a JSON matrix for job 2.
 | `one-arch` + arm64 | 1 job: Ubuntu 26.04 arm64 |
 | `all-archs` | 2 jobs: amd64 + arm64 |
 
-It also passes through **scenario**, **skip_update**, and **region**.
+It also passes through **scenario** and **skip_update**. Region is resolved in job 2 directly from `github.event.inputs.aws_region` or `secrets.AWS_TEST_REGION` (Actions redacts secret-bearing job outputs to empty, so region must not cross the job boundary via outputs).
 
 ### 4. Job 2: `aws-remote-tests` (main work)
 

--- a/tests/unit/test_aws_remote_workflow_secrets.py
+++ b/tests/unit/test_aws_remote_workflow_secrets.py
@@ -6,10 +6,9 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-WORKFLOWS = (
-    REPO_ROOT / ".github" / "workflows" / "aws-remote-tests.yml",
-    REPO_ROOT / ".github" / "workflows" / "rc-aws-remote-tests.yml",
-)
+AWS_REMOTE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "aws-remote-tests.yml"
+RC_AWS_REMOTE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rc-aws-remote-tests.yml"
+WORKFLOWS = (AWS_REMOTE_WORKFLOW, RC_AWS_REMOTE_WORKFLOW)
 
 INFRA_SECRETS = (
     "AWS_TEST_REGION",
@@ -34,6 +33,30 @@ class AwsRemoteWorkflowSecretsTests(unittest.TestCase):
                         text,
                         f"{workflow.name} must not reference vars.{name}",
                     )
+
+    def test_aws_region_is_not_passed_through_job_outputs(self) -> None:
+        """Secrets in job outputs are redacted to empty by the Actions runner."""
+        text = AWS_REMOTE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "aws_region: ${{ steps.matrix.outputs.aws_region }}",
+            text,
+        )
+        self.assertNotIn(
+            "AWS_REGION: ${{ needs.prepare-matrix.outputs.aws_region }}",
+            text,
+        )
+        self.assertIn(
+            "AWS_REGION: ${{ github.event.inputs.aws_region || secrets.AWS_TEST_REGION }}",
+            text,
+        )
+
+    def test_cleanup_skips_when_checkout_did_not_run(self) -> None:
+        text = AWS_REMOTE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("Repository checkout did not run; skipping destroy.", text)
+        self.assertIn(
+            "Repository checkout did not run; skipping cleanup verification.",
+            text,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #201

## Summary

- Resolve `AWS_REGION` in the AWS remote test job from the dispatch input or `AWS_TEST_REGION` secret instead of a prepare-matrix job output (Actions redacts secret-bearing outputs to empty).
- Skip destroy/verify cleanup when checkout never ran so early validation failures do not cascade.
- Add unit tests and a short workflow doc note for the regression.

## Release notes

- Proposed release note sentence:
  - `N/A — CI-only fix for scheduled AWS remote tests`
- Changelog type:
  - [ ] `feat`
  - [ ] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-lint / yamllint (or N/A)
- [x] syntax checks for changed playbooks/roles (or N/A)
- [x] Molecule / remote tests when behavior changes (or N/A)
- [x] README / docs updated when needed

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit


Made with [Cursor](https://cursor.com)