### PR TITLE
chore(deps): bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v4
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Match changed paths
         id: filter
         if: github.event_name != 'workflow_dispatch'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           # "every" makes negation patterns act as exclusions; the default
           # "some" quantifier lets the bare '**' match everything.

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Match changed paths
         id: filter
         if: github.event_name != 'workflow_dispatch'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           # "every" makes negation patterns act as exclusions; the default
           # "some" quantifier lets the bare '**' match everything.

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -83,7 +83,7 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v4
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
         if: >-
           github.event_name != 'workflow_dispatch' &&
           github.event_name != 'schedule'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           # "every" makes negation patterns act as exclusions; the default
           # "some" quantifier lets the bare '**' match everything.
@@ -83,13 +83,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.36.2
+        uses: github/codeql-action/init@v4.37.0
         with:
           languages: actions
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4.36.2
+        uses: github/codeql-action/analyze@v4.37.0
 
   trivy:
     name: Trivy filesystem scan
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Trivy results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.36.2
+        uses: github/codeql-action/upload-sarif@v4.37.0
         with:
           sarif_file: trivy-results.sarif
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload Trivy image results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.36.2
+        uses: github/codeql-action/upload-sarif@v4.37.0
         with:
           sarif_file: trivy-${{ matrix.key }}.sarif
           category: trivy-image-${{ matrix.key }}


### PR DESCRIPTION
## Summary

- Consolidates open Dependabot PRs into one branch based on current `master`
- Bumps `dorny/paths-filter` to v4.0.2 with a commit SHA pin (Dependabot’s `@v4` tag failed CodeQL `actions/unpinned-tag`)
- Bumps `github/codeql-action` 4.36.2 → 4.37.0
- Bumps `aws-actions/configure-aws-credentials` to 6.2.2

Supersedes #198, #199, and #200.

## Release notes

- Proposed release note sentence:
  - `N/A — CI dependency bumps only`
- Changelog type:
  - [ ] `feat`
  - [ ] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [ ] ansible-lint / yamllint (or N/A)
- [ ] syntax checks for changed playbooks/roles (or N/A)
- [ ] Molecule / remote tests when behavior changes (or N/A)
- [x] README / docs updated when needed (N/A)

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit


Made with [Cursor](https://cursor.com)