### PR TITLE
chore(deps): bump ansible-core to 2.21.2 and setup-python to 6.3.0

### DIFF
--- a/.github/actions/import-galaxy-role/action.yml
+++ b/.github/actions/import-galaxy-role/action.yml
@@ -20,13 +20,13 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v6.3.0
       with:
         python-version: "3.13"
 
     - name: Install Ansible
       shell: bash
-      run: python -m pip install 'ansible-core>=2.21.1,<2.22'
+      run: python -m pip install 'ansible-core>=2.21.2,<2.22'
 
     - name: Import role into Ansible Galaxy
       shell: bash

--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -186,14 +186,14 @@ jobs:
           role-session-name: ansible-pihole-aws-tests
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.1,<2.22'
+          python -m pip install --upgrade 'ansible-core>=2.21.2,<2.22'
 
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,14 +114,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.1,<2.22' ansible-lint yamllint galaxy-importer
+          python -m pip install --upgrade 'ansible-core>=2.21.2,<2.22' ansible-lint yamllint galaxy-importer
 
       - name: Build and validate collection for Ansible Galaxy
         run: |
@@ -158,7 +158,7 @@ jobs:
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
         python-version: ["3.13", "3.14"]
-        ansible-core: [">=2.20.5,<2.21", ">=2.21.1,<2.22"]
+        ansible-core: [">=2.20.5,<2.21", ">=2.21.2,<2.22"]
 
     steps:
       - name: Checkout
@@ -167,7 +167,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -219,7 +219,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
@@ -287,7 +287,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -73,14 +73,14 @@ jobs:
       matrix:
         ansible-core:
           - ">=2.20.5,<2.21"
-          - ">=2.21.1,<2.22"
+          - ">=2.21.2,<2.22"
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/pihole-image-watch.yml
+++ b/.github/workflows/pihole-image-watch.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -90,14 +90,14 @@ jobs:
           role-session-name: ansible-pihole-rc-ubuntu-26.04
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.1,<2.22'
+          python -m pip install --upgrade 'ansible-core>=2.21.2,<2.22'
 
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -199,7 +199,7 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.13"
 
@@ -207,7 +207,7 @@ jobs:
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
         run: |
-          python -m pip install --upgrade pip 'ansible-core>=2.21.1,<2.22'
+          python -m pip install --upgrade pip 'ansible-core>=2.21.2,<2.22'
           ansible-galaxy collection build
           if [ -z "${GALAXY_API_KEY:-}" ]; then
             echo "GALAXY_API_KEY is not set; skipping Galaxy publish."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
         always_run: true
         pass_filenames: false
         additional_dependencies:
-          - ansible-core==2.21.1
+          - ansible-core==2.21.2
         env:
           ANSIBLE_CONFIG: ansible.cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Normal developer toolchain (Python 3.13 or 3.14).
 # CI also tests the supported ansible-core 2.20 runtime floor.
-ansible-core>=2.21.1,<2.22
+ansible-core>=2.21.2,<2.22
 ansible-lint>=26.6.0
 yamllint>=1.38.0
 molecule>=26.6.0

--- a/scripts/check-ansible-version-policy.py
+++ b/scripts/check-ansible-version-policy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 MINIMUM = ">=2.20.5,<2.21"
-LATEST = ">=2.21.1,<2.22"
+LATEST = ">=2.21.2,<2.22"
 
 
 def require(path: str, text: str) -> None:


### PR DESCRIPTION
Fixes #211

Supersedes #208, #209, #210.

## Summary

- Raise ansible-core support floor to `>=2.21.2,<2.22` (requirements, policy, CI, pre-commit)
- Pin `actions/setup-python` to `v6.3.0` across workflows and the Galaxy import action
- Force release-please patch via `Release-As: 1.8.3` so these land in a new release

## Release notes

- Proposed release note sentence:
  - `Bump ansible-core floor to 2.21.2 and pin actions/setup-python to 6.3.0.`
- Changelog type:
  - [ ] `feat`
  - [ ] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [x] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-lint / yamllint (or N/A) — pending CI
- [x] `scripts/check-ansible-version-policy.py` passes locally
- [ ] Molecule / remote tests when behavior changes (or N/A)
- [x] README / docs updated when needed (N/A — still “2.20 or 2.21”)

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit


Made with [Cursor](https://cursor.com)