### PR TITLE
fix: stabilize Rocky Molecule SSH, Unbound, and VIP health

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ keepalived_enable_ip_forward: true
 On RedHat/Rocky, `keepalived_t` remains enforcing by default. The
 `keepalived_selinux_permissive: true` compatibility escape hatch weakens
 SELinux enforcement and should only be used for a known denial while a narrow
-policy fix is prepared.
+policy fix is prepared. Vagrant lab inventories enable it so keepalived can run
+the docker/dig VIP health script under Molecule without a custom SELinux module.
 
 `docker_disable_ipv6` now defaults to `false` for production safety. Set it explicitly in
 lab inventories where guest networking requires the workaround (for example Vagrant/Rocky).
@@ -246,7 +247,10 @@ Pi-hole uses. After all nodes pass and rejoin, the playbooks verify DNS through
 the VIP.
 
 Keepalived health checks require both the configured Pi-hole container to be
-running and Pi-hole DNS to answer functionally. Container checks use `sg docker`
+running and Pi-hole DNS to answer functionally. When Unbound is enabled, the
+check also probes Unbound (preferring the container's live IPv4 from
+`docker inspect` so VIP health still works if Docker embedded DNS is down).
+Container checks use `sg docker`
 so they work under keepalived's script execution context. This prevents another
 local DNS listener from masking a stopped Pi-hole container during HA failover.
 
@@ -264,7 +268,10 @@ The Vagrant inventories set `docker_daemon_dns` and `pihole_docker_dns` to
 public resolvers so Docker Hub image pulls and fresh Pi-hole gravity bootstrap
 do not depend on guest-local stub or embedded Docker DNS before Pi-hole/Unbound
 are healthy. Leave these unset or empty in production unless the host or
-container needs an explicit resolver list.
+container needs an explicit resolver list. On lab hosts where Docker does not
+manage iptables (typical Vagrant/`vagrant_env`), the Pi-hole role falls back to
+Unbound's bridge IPv4 for `FTLCONF_dns_upstreams` because `127.0.0.11` is often
+refused inside the container.
 
 ### `playbooks/keepalived.yaml`
 
@@ -306,6 +313,8 @@ services during each converge.
 
 - Molecule, Ansible, Vagrant, and **VirtualBox** or **libvirt** (`vagrant-libvirt`) as appropriate.
 - Run Molecule from the **repository root** so paths and inventory links resolve.
+- Vagrant inventories set `IdentitiesOnly=yes` in `ansible_ssh_common_args` so a busy
+  `ssh-agent` does not exhaust MaxAuthTries before the Vagrant key (or password) is tried.
 - **Lint:** CI runs [ansible-lint](https://ansible-lint.readthedocs.io/) on
   roles, playbooks, Molecule, and remote verification playbooks;
   [yamllint](https://yamllint.readthedocs.io/) covers their YAML inventories and

--- a/inventory/vagrant.yml
+++ b/inventory/vagrant.yml
@@ -26,7 +26,8 @@ all:
     ansible_user: vagrant
     ansible_password: vagrant  # only used on first run
     # Avoid failing on local /etc/ssh/ssh_config* permission issues; also suppress hostkey prompts.
-    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    # IdentitiesOnly: avoid "Too many authentication failures" when ssh-agent holds many keys.
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     password_lock: false  # Change to false if you still wish to login via passwd auth
     ansible_user_home_dir: /home/{{ ansible_user }}
     ansible_python_interpreter: /usr/bin/python3
@@ -55,6 +56,9 @@ all:
     dnsmasq_listening: single
     pihole_container_name: pihole
     vagrant_env: true
+    # Rocky/EL keepalived_t cannot run the docker/dig health script under enforcing
+    # without a custom policy; lab escape hatch (defaults stay enforcing for production).
+    keepalived_selinux_permissive: true
     docker_group_users:
       - vagrant
     # Lab-only: avoid Docker image pulls depending on the guest's systemd-resolved stub.

--- a/inventory/vagrant_libvirt.yml
+++ b/inventory/vagrant_libvirt.yml
@@ -23,6 +23,8 @@ all:
     ansible_user: vagrant
     ansible_password: vagrant  # only used on first run
     password_lock: false  # Change to false if you still wish to login via passwd auth
+    # IdentitiesOnly: avoid "Too many authentication failures" when ssh-agent holds many keys.
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     ansible_user_home_dir: /home/{{ ansible_user }}
     ansible_python_interpreter: /usr/bin/python3
     github_user_for_ssh_key: steveyminecraft  # Change me to required value
@@ -48,6 +50,9 @@ all:
     dnsmasq_listening: single
     pihole_container_name: pihole
     vagrant_env: true
+    # Rocky/EL keepalived_t cannot run the docker/dig health script under enforcing
+    # without a custom policy; lab escape hatch (defaults stay enforcing for production).
+    keepalived_selinux_permissive: true
     docker_disable_ipv6: true  # lab-only workaround for Rocky/Vagrant guest networking
     docker_enable_ip_forward: true  # lab bridge/NAT topology requires forwarding
     docker_group_users:

--- a/inventory/vagrant_no_unbound.yml
+++ b/inventory/vagrant_no_unbound.yml
@@ -11,7 +11,8 @@ all:
     ansible_password: vagrant
     ansible_user_home_dir: /home/vagrant
     ansible_python_interpreter: /usr/bin/python3
-    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    # IdentitiesOnly: avoid "Too many authentication failures" when ssh-agent holds many keys.
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     github_user_for_ssh_key: steveyminecraft
     password_lock: false
     timezone: Europe/London

--- a/inventory/vagrant_no_unbound_libvirt.yml
+++ b/inventory/vagrant_no_unbound_libvirt.yml
@@ -11,7 +11,8 @@ all:
     ansible_password: vagrant
     ansible_user_home_dir: /home/vagrant
     ansible_python_interpreter: /usr/bin/python3
-    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    # IdentitiesOnly: avoid "Too many authentication failures" when ssh-agent holds many keys.
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     github_user_for_ssh_key: steveyminecraft
     password_lock: false
     timezone: Europe/London

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
     # Rocky 9/10 images commonly disable password SSH for vagrant; use Vagrant's insecure key
     # (the Vagrantfile provisions the matching public key into vagrant's authorized_keys).
     ansible_ssh_private_key_file: ${HOME}/.vagrant.d/insecure_private_key
-    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     ansible_become: true
   inventory:
     links:

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -30,7 +30,7 @@ provisioner:
   connection_options:
     ansible_ssh_user: vagrant
     ansible_ssh_private_key_file: ${HOME}/.vagrant.d/insecure_private_key
-    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     ansible_become: true
   inventory:
     links:

--- a/molecule/ubuntu-26.04/molecule.yml
+++ b/molecule/ubuntu-26.04/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
     ansible_ssh_user: vagrant
     ansible_password: vagrant
     ansible_ssh_private_key_file: ${HOME}/.vagrant.d/insecure_private_key
-    ansible_ssh_common_args: "-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    ansible_ssh_common_args: "-F /dev/null -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     ansible_become: true
   inventory:
     links:

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -9,8 +9,12 @@ The health script (`/etc/keepalived/check_pihole.sh`) requires:
 2. A functional DNS query against local Pi-hole on `127.0.0.1:53` that returns
    at least one IPv4 answer for `pihole_verify_qname` (default `cloudflare.com`).
 3. When `pihole_enable_unbound` is true, Unbound must also be running and answer
-   the same qname on port `5335`. Pi-hole cache alone is not enough — otherwise
-   upstream failure would not trigger VIP failover.
+   the same qname on port `5335`. The script prefers Unbound's live container
+   IPv4 from `docker inspect` (fallback: `UNBOUND_DNS_TARGET` / the Docker
+   service name) so VIP health still works when keepalived was configured before
+   Unbound's address was known, or when Docker embedded DNS is unavailable.
+   Pi-hole cache alone is not enough — otherwise upstream failure would not
+   trigger VIP failover.
 
 Container checks use `sg docker` so they still work when keepalived runs the
 script without supplementary groups. The script uses `set -o pipefail` only

--- a/roles/keepalived/templates/check_pihole.sh.j2
+++ b/roles/keepalived/templates/check_pihole.sh.j2
@@ -41,8 +41,20 @@ fi
 sg docker -c "docker inspect --format '{{ '{{' }}.State.Running{{ '}}' }}' \"${UNBOUND_CONTAINER}\"" 2>/dev/null \
   | grep -qx true || exit 1
 
+# Prefer Unbound's live container IPv4: keepalived.conf/script are often rendered
+# before Pi-hole sets pihole_unbound_dns_target, and Docker embedded DNS
+# (127.0.0.11) is frequently refused when iptables management is off.
+UNBOUND_CHECK_TARGET="$(
+  sg docker -c "docker inspect --format '{{ '{{' }}range .NetworkSettings.Networks{{ '}}' }}{{ '{{' }}.IPAddress{{ '}}' }}{{ '{{' }}println{{ '}}' }}{{ '{{' }}end{{ '}}' }}' \"${UNBOUND_CONTAINER}\"" 2>/dev/null \
+    | awk 'NF { print; exit }'
+)"
+if [ -z "${UNBOUND_CHECK_TARGET}" ]; then
+  UNBOUND_CHECK_TARGET="${UNBOUND_DNS_TARGET}"
+fi
+[ -n "${UNBOUND_CHECK_TARGET}" ] || exit 1
+
 sg docker -c "docker exec \"${PIHOLE_CONTAINER}\" sh -lc \
-  \"dig +time=1 +tries=1 +short @${UNBOUND_DNS_TARGET} -p ${UNBOUND_PORT} ${PIHOLE_HEALTH_DOMAIN}\"" \
+  \"dig +time=1 +tries=1 +short @${UNBOUND_CHECK_TARGET} -p ${UNBOUND_PORT} ${PIHOLE_HEALTH_DOMAIN}\"" \
   | ipv4_answer || exit 1
 {% endif %}
 

--- a/roles/pihole/tasks/unbound.yml
+++ b/roles/pihole/tasks/unbound.yml
@@ -45,10 +45,26 @@
   when: pihole_unbound_present
 
 # Prefer the Docker DNS name so Pi-hole survives Unbound IP changes on dns_net.
+# Fall back to bridge IPv4 when embedded DNS (127.0.0.11) is unavailable: Docker
+# iptables off (common on EL/Vagrant), custom container dns:, or explicit override.
 # The bridge IPv4 is still collected above for host-side dig verification.
 - name: Set Pi-hole Unbound DNS target
   ansible.builtin.set_fact:
-    pihole_unbound_dns_target: "{{ unbound_container_name | default('unbound') }}"
+    pihole_unbound_dns_target: >-
+      {{
+        (
+          pihole_unbound_container_ipv4
+          if (
+            (pihole_unbound_container_ipv4 | default('') | length > 0)
+            and (
+              not (pihole_docker_manage_iptables | default(true) | bool)
+              or (pihole_docker_dns | default([]) | length > 0)
+              or (pihole_override_container_resolver | default(false) | bool)
+            )
+          )
+          else (unbound_container_name | default('unbound'))
+        )
+      }}
   when: pihole_unbound_present
 
 - name: Use public DNS as Pi-hole container startup resolver

--- a/tests/unit/test_keepalived_health_script.py
+++ b/tests/unit/test_keepalived_health_script.py
@@ -1,0 +1,54 @@
+"""Contract tests for keepalived Pi-hole health script template."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = ROOT / "roles" / "keepalived" / "templates" / "check_pihole.sh.j2"
+
+
+class KeepalivedHealthScriptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        env = Environment(
+            loader=FileSystemLoader(TEMPLATE.parent),
+            undefined=StrictUndefined,
+            keep_trailing_newline=True,
+        )
+        env.filters["bool"] = lambda value: (
+            value if isinstance(value, bool) else str(value).lower() in ("true", "1", "yes")
+        )
+        cls.env = env
+
+    def _render(self, **overrides: object) -> str:
+        variables = {
+            "ansible_user": "vagrant",
+            "pihole_container_name": "pihole",
+            "pihole_verify_qname": "cloudflare.com",
+            "pihole_enable_unbound": True,
+            "unbound_container_name": "unbound",
+            "unbound_port": 5335,
+            "pihole_unbound_dns_target": "unbound",
+        }
+        variables.update(overrides)
+        return self.env.get_template(TEMPLATE.name).render(**variables)
+
+    def test_unbound_probe_discovers_container_ip_at_runtime(self) -> None:
+        rendered = self._render()
+        self.assertIn("UNBOUND_CHECK_TARGET=", rendered)
+        self.assertIn("NetworkSettings.Networks", rendered)
+        self.assertIn("@${UNBOUND_CHECK_TARGET}", rendered)
+        self.assertIn("UNBOUND_DNS_TARGET", rendered)
+
+    def test_unbound_probe_omitted_when_unbound_disabled(self) -> None:
+        rendered = self._render(pihole_enable_unbound=False)
+        self.assertNotIn("UNBOUND_CHECK_TARGET=", rendered)
+        self.assertNotIn("UNBOUND_CONTAINER", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_pihole_unbound_dns_target.py
+++ b/tests/unit/test_pihole_unbound_dns_target.py
@@ -1,0 +1,102 @@
+"""Contract and Jinja selection tests for Pi-hole Unbound DNS target."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, StrictUndefined
+
+ROOT = Path(__file__).resolve().parents[2]
+UNBOUND_TASKS = ROOT / "roles" / "pihole" / "tasks" / "unbound.yml"
+
+
+def _ansible_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in ("true", "1", "yes")
+
+
+def _render_target(**variables: object) -> str:
+    """Evaluate the same selection expression used by unbound.yml."""
+    env = Environment(undefined=StrictUndefined)
+    env.filters["bool"] = _ansible_bool
+    template = env.from_string(
+        """
+{%- set use_ip = (
+  (pihole_unbound_container_ipv4 | default('') | length > 0)
+  and (
+    (not (pihole_docker_manage_iptables | default(true) | bool))
+    or (pihole_docker_dns | default([]) | length > 0)
+    or (pihole_override_container_resolver | default(false) | bool)
+  )
+) -%}
+{{- pihole_unbound_container_ipv4 if use_ip else (unbound_container_name | default('unbound')) -}}
+"""
+    )
+    return template.render(**variables)
+
+
+class PiholeUnboundDnsTargetTests(unittest.TestCase):
+    def test_unbound_tasks_prefer_ip_when_embedded_dns_unavailable(self) -> None:
+        tasks = yaml.safe_load(UNBOUND_TASKS.read_text(encoding="utf-8"))
+        target_task = next(
+            task for task in tasks if task.get("name") == "Set Pi-hole Unbound DNS target"
+        )
+        expression = target_task["ansible.builtin.set_fact"]["pihole_unbound_dns_target"]
+        self.assertIn("pihole_unbound_container_ipv4", expression)
+        self.assertIn("pihole_docker_manage_iptables", expression)
+        self.assertIn("pihole_docker_dns", expression)
+
+        verify_task = next(
+            task
+            for task in tasks
+            if task.get("name") == "Verify Pi-hole can resolve Unbound via Docker embedded DNS"
+        )
+        when_clause = verify_task.get("when")
+        self.assertIsInstance(when_clause, list)
+        self.assertTrue(
+            any("pihole_unbound_dns_target ==" in str(item) for item in when_clause),
+            msg="embedded DNS verify must run only when target is the Docker service name",
+        )
+
+    def test_production_defaults_keep_docker_service_name(self) -> None:
+        self.assertEqual(
+            _render_target(
+                pihole_unbound_container_ipv4="172.18.0.2",
+                pihole_docker_manage_iptables=True,
+                pihole_docker_dns=[],
+                pihole_override_container_resolver=False,
+                unbound_container_name="unbound",
+            ),
+            "unbound",
+        )
+
+    def test_vagrant_iptables_false_with_custom_dns_uses_bridge_ip(self) -> None:
+        self.assertEqual(
+            _render_target(
+                pihole_unbound_container_ipv4="172.18.0.2",
+                pihole_docker_manage_iptables=False,
+                pihole_docker_dns=["1.1.1.1", "8.8.8.8"],
+                pihole_override_container_resolver=False,
+                unbound_container_name="unbound",
+            ),
+            "172.18.0.2",
+        )
+
+    def test_explicit_resolver_override_uses_bridge_ip(self) -> None:
+        self.assertEqual(
+            _render_target(
+                pihole_unbound_container_ipv4="172.18.0.2",
+                pihole_docker_manage_iptables=True,
+                pihole_docker_dns=[],
+                pihole_override_container_resolver=True,
+                unbound_container_name="unbound",
+            ),
+            "172.18.0.2",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #214

## Summary

- Fix Vagrant/Molecule SSH auth with `IdentitiesOnly=yes` when many agent keys are loaded
- Fall back to Unbound bridge IPv4 when Docker embedded DNS is unavailable (lab iptables off / custom container DNS)
- Discover Unbound container IP at runtime in keepalived health checks; enable lab `keepalived_selinux_permissive` so Rocky VIP comes up

## Release notes

- Proposed release note sentence:
  - `Molecule/Vagrant Rocky HA tests no longer fail on SSH agent key floods, broken Docker embedded DNS, or SELinux-blocked keepalived health checks.`
- Changelog type:
  - [ ] `feat`
  - [x] `fix`
  - [ ] `perf`
  - [ ] `refactor`
  - [ ] non-user-facing (`docs` / `ci` / `chore` / `test` / `build`)

## Validation

- [x] ansible-lint / yamllint (or N/A) — N/A locally this run; CI on PR
- [x] syntax checks for changed playbooks/roles (or N/A) — covered by `molecule test` syntax step
- [x] Molecule / remote tests when behavior changes — `molecule test -s default` (VirtualBox Rocky) passed create → destroy
- [x] README / docs updated when needed
- [x] Unit tests: `test_pihole_unbound_dns_target`, `test_keepalived_health_script` (52 suite tests passed on push)

## Scope and risk

- Risk level: [x] low  [ ] medium  [ ] high
- Rollback plan: revert PR merge commit


Made with [Cursor](https://cursor.com)