### PR TITLE
chore(deps): bump ansible-core floor to 2.21.3

### DIFF
--- a/.github/actions/import-galaxy-role/action.yml
+++ b/.github/actions/import-galaxy-role/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Install Ansible
       shell: bash
-      run: python -m pip install 'ansible-core>=2.21.2,<2.22'
+      run: python -m pip install 'ansible-core>=2.21.3,<2.22'
 
     - name: Import role into Ansible Galaxy
       shell: bash

--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.2,<2.22'
+          python -m pip install --upgrade 'ansible-core>=2.21.3,<2.22'
 
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.2,<2.22' ansible-lint yamllint galaxy-importer
+          python -m pip install --upgrade 'ansible-core>=2.21.3,<2.22' ansible-lint yamllint galaxy-importer
 
       - name: Build and validate collection for Ansible Galaxy
         run: |
@@ -158,7 +158,7 @@ jobs:
       matrix:
         runner: [ubuntu-24.04, ubuntu-24.04-arm]
         python-version: ["3.13", "3.14"]
-        ansible-core: [">=2.20.5,<2.21", ">=2.21.2,<2.22"]
+        ansible-core: [">=2.20.5,<2.21", ">=2.21.3,<2.22"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         ansible-core:
           - ">=2.20.5,<2.21"
-          - ">=2.21.2,<2.22"
+          - ">=2.21.3,<2.22"
 
     steps:
       - name: Check out repository

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade 'ansible-core>=2.21.2,<2.22'
+          python -m pip install --upgrade 'ansible-core>=2.21.3,<2.22'
 
       - name: Install collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -207,7 +207,7 @@ jobs:
         env:
           GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
         run: |
-          python -m pip install --upgrade pip 'ansible-core>=2.21.2,<2.22'
+          python -m pip install --upgrade pip 'ansible-core>=2.21.3,<2.22'
           ansible-galaxy collection build
           if [ -z "${GALAXY_API_KEY:-}" ]; then
             echo "GALAXY_API_KEY is not set; skipping Galaxy publish."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
         always_run: true
         pass_filenames: false
         additional_dependencies:
-          - ansible-core==2.21.2
+          - ansible-core==2.21.3
         env:
           ANSIBLE_CONFIG: ansible.cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Normal developer toolchain (Python 3.13 or 3.14).
 # CI also tests the supported ansible-core 2.20 runtime floor.
-ansible-core>=2.21.2,<2.22
+ansible-core>=2.21.3,<2.22
 ansible-lint>=26.6.0
 yamllint>=1.38.0
 molecule>=26.6.0

--- a/scripts/check-ansible-version-policy.py
+++ b/scripts/check-ansible-version-policy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 MINIMUM = ">=2.20.5,<2.21"
-LATEST = ">=2.21.2,<2.22"
+LATEST = ">=2.21.3,<2.22"
 
 
 def require(path: str, text: str) -> None:


### PR DESCRIPTION
## Summary
- Raises the documented/tested ansible-core 2.21 floor from `2.21.2` to `2.21.3` in requirements, CI, Galaxy, pre-commit, and the policy script.
- Bundles Dependabot PRs [#223](https://github.com/steveyminecraft/ansible-pihole/pull/223) and [#224](https://github.com/steveyminecraft/ansible-pihole/pull/224). #223 fails alone because `scripts/check-ansible-version-policy.py` still required `>=2.21.2,<2.22`.

## Test plan
- [ ] Confirm `python scripts/check-ansible-version-policy.py` passes
- [ ] Confirm CI policy/script validation, lint, and ansible-core 2.21.3 matrix jobs are green
- [ ] Close Dependabot PRs #223 and #224 as superseded after merge


Made with [Cursor](https://cursor.com)