### PR TITLE
chore(deps): bump ansible-lint, molecule, and codeql-action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,13 +83,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.6
+        uses: github/codeql-action/init@v4.37.7
         with:
           languages: actions
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4.37.6
+        uses: github/codeql-action/analyze@v4.37.7
 
   trivy:
     name: Trivy filesystem scan
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Trivy results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.37.6
+        uses: github/codeql-action/upload-sarif@v4.37.7
         with:
           sarif_file: trivy-results.sarif
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload Trivy image results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.37.6
+        uses: github/codeql-action/upload-sarif@v4.37.7
         with:
           sarif_file: trivy-${{ matrix.key }}.sarif
           category: trivy-image-${{ matrix.key }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - .yamllint
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v26.6.0
+    rev: v26.8.0
     hooks:
       - id: ansible-lint
         args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Normal developer toolchain (Python 3.13 or 3.14).
 # CI also tests the supported ansible-core 2.20 runtime floor.
 ansible-core>=2.21.3,<2.22
-ansible-lint>=26.6.0
+ansible-lint>=26.8.0
 yamllint>=1.38.0
-molecule>=26.6.0
+molecule>=26.8.0
 molecule-vagrant>=2.0.0
 molecule-docker>=2.1.0
 testinfra>=6.0.0


### PR DESCRIPTION
## Summary
- Bundles the four open Dependabot updates into one PR so the two `requirements.txt` bumps do not conflict.
- Raises `ansible-lint` and `molecule` floors from 26.6.0 to 26.8.0 (pip + pre-commit).
- Pins `github/codeql-action` from 4.37.6 to 4.37.7.

Supersedes #226, #227, #228, and #229.

## Test plan
- [ ] CI - Ansible-Pihole Checks is green
- [ ] Security scanning (CodeQL + Trivy) is green
- [ ] Galaxy validation is green
- [ ] After merge, Dependabot PRs #226–#229 close automatically


Made with [Cursor](https://cursor.com)