### PR TITLE
ci: enqueue LAN deploy after successful master CI

### DIFF
--- a/.github/workflows/deploy-lan-queue.yml
+++ b/.github/workflows/deploy-lan-queue.yml
@@ -1,0 +1,75 @@
+---
+# After CI on master succeeds, SendMessage to the shared LAN deploy queue.
+# GitHub runners must not open a remote shell or invoke playbooks.
+#
+# Repository variables:
+#   AWS_DEPLOY_QUEUE_ROLE_ARN  terraform output github_deploy_queue_send_role_arn
+#   AWS_DEPLOY_QUEUE_URL       terraform output github_deploy_queue_url
+#   AWS_REGION                 eu-west-1
+
+name: Deploy to LAN queue
+
+on:  # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows:
+      - CI - Ansible-Pihole Checks
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  enqueue:
+    name: Enqueue master SHA
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'master')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate repository variables
+        env:
+          AWS_DEPLOY_QUEUE_ROLE_ARN: ${{ vars.AWS_DEPLOY_QUEUE_ROLE_ARN }}
+          AWS_DEPLOY_QUEUE_URL: ${{ vars.AWS_DEPLOY_QUEUE_URL }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          for var_name in AWS_DEPLOY_QUEUE_ROLE_ARN AWS_DEPLOY_QUEUE_URL AWS_REGION; do
+            if [ -z "${!var_name:-}" ]; then
+              echo "Missing required repository variable: ${var_name}"
+              exit 1
+            fi
+          done
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_QUEUE_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-session-name: ansible-pihole-lan-queue
+
+      - name: Send deploy message
+        env:
+          QUEUE_URL: ${{ vars.AWS_DEPLOY_QUEUE_URL }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            SHA="${GITHUB_SHA}"
+            REF="${GITHUB_REF}"
+          else
+            SHA="${{ github.event.workflow_run.head_sha }}"
+            REF="refs/heads/${{ github.event.workflow_run.head_branch }}"
+          fi
+          BODY=$(jq -nc \
+            --arg repo "${GITHUB_REPOSITORY}" \
+            --arg sha "$SHA" \
+            --arg ref "$REF" \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            '{repo:$repo,sha:$sha,ref:$ref,run_id:$run_id}')
+          aws sqs send-message --queue-url "$QUEUE_URL" --message-body "$BODY"

--- a/.github/workflows/deploy-lan-queue.yml
+++ b/.github/workflows/deploy-lan-queue.yml
@@ -57,14 +57,16 @@ jobs:
       - name: Send deploy message
         env:
           QUEUE_URL: ${{ vars.AWS_DEPLOY_QUEUE_URL }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             SHA="${GITHUB_SHA}"
             REF="${GITHUB_REF}"
           else
-            SHA="${{ github.event.workflow_run.head_sha }}"
-            REF="refs/heads/${{ github.event.workflow_run.head_branch }}"
+            SHA="${WORKFLOW_SHA}"
+            REF="refs/heads/${WORKFLOW_BRANCH}"
           fi
           BODY=$(jq -nc \
             --arg repo "${GITHUB_REPOSITORY}" \

--- a/tests/unit/test_deploy_lan_queue_workflow.py
+++ b/tests/unit/test_deploy_lan_queue_workflow.py
@@ -35,6 +35,27 @@ class DeployLanQueueWorkflowTests(unittest.TestCase):
         self.assertIn("head_branch == 'master'", self.text)
         self.assertIn("id-token: write", self.text)
 
+    def test_workflow_run_fields_are_passed_via_env_not_shell_interpolation(self) -> None:
+        """CodeQL actions/code-injection: do not expand workflow_run into run: scripts."""
+        self.assertNotIn(
+            'SHA="${{ github.event.workflow_run.head_sha }}"',
+            self.text,
+        )
+        self.assertNotIn(
+            'REF="refs/heads/${{ github.event.workflow_run.head_branch }}"',
+            self.text,
+        )
+        self.assertIn(
+            "WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}",
+            self.text,
+        )
+        self.assertIn(
+            "WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}",
+            self.text,
+        )
+        self.assertIn('SHA="${WORKFLOW_SHA}"', self.text)
+        self.assertIn('REF="refs/heads/${WORKFLOW_BRANCH}"', self.text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_deploy_lan_queue_workflow.py
+++ b/tests/unit/test_deploy_lan_queue_workflow.py
@@ -1,0 +1,40 @@
+"""Guard the LAN deploy-queue workflow contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-lan-queue.yml"
+
+
+class DeployLanQueueWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_workflow_file_exists(self) -> None:
+        self.assertTrue(WORKFLOW.is_file())
+
+    def test_does_not_ssh_or_run_ansible(self) -> None:
+        self.assertNotIn("ansible-playbook", self.text)
+        self.assertNotRegex(self.text, r"(?m)^\s+ssh\s")
+        self.assertNotIn("appleboy/ssh-action", self.text)
+
+    def test_uses_shared_queue_variables_not_github_build_secret(self) -> None:
+        self.assertIn("vars.AWS_DEPLOY_QUEUE_ROLE_ARN", self.text)
+        self.assertIn("vars.AWS_DEPLOY_QUEUE_URL", self.text)
+        self.assertIn("vars.AWS_REGION", self.text)
+        self.assertNotIn("secrets.AWS_TEST_ROLE_ARN", self.text)
+        self.assertIn("aws sqs send-message", self.text)
+
+    def test_enqueues_after_successful_master_ci(self) -> None:
+        self.assertIn("CI - Ansible-Pihole Checks", self.text)
+        self.assertIn("workflow_run", self.text)
+        self.assertIn("head_branch == 'master'", self.text)
+        self.assertIn("id-token: write", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- After `CI - Ansible-Pihole Checks` succeeds on `master`, SendMessage to the shared GitHub → SQS → LAN queue (`{repo,sha,ref,run_id}`).
- Uses OIDC send role + repository variables (`AWS_DEPLOY_QUEUE_ROLE_ARN`, `AWS_DEPLOY_QUEUE_URL`, `AWS_REGION`). GitHub runners do not SSH or run playbooks.
- Repo variables are already set. The prod-01 poller still omits `ansible-pihole` from its allowlist, so messages will be ignored until that line is added.

## Test plan
- [ ] Unit tests: `python3 -m unittest tests.unit.test_deploy_lan_queue_workflow -v`
- [ ] CI on this PR is green
- [ ] After merge, next successful `master` CI run starts **Deploy to LAN queue**
- [ ] Workflow logs show `send-message` (poller `skip_unknown` until allowlist opt-in)


Made with [Cursor](https://cursor.com)