### PR TITLE
chore(deps): bump codeql-action and configure-aws-credentials

### DIFF
--- a/.github/workflows/aws-remote-tests.yml
+++ b/.github/workflows/aws-remote-tests.yml
@@ -179,7 +179,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-lan-queue.yml
+++ b/.github/workflows/deploy-lan-queue.yml
@@ -48,7 +48,7 @@ jobs:
           done
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_QUEUE_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/rc-aws-remote-tests.yml
+++ b/.github/workflows/rc-aws-remote-tests.yml
@@ -83,7 +83,7 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,13 +83,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.7
+        uses: github/codeql-action/init@v4.37.9
         with:
           languages: actions
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4.37.7
+        uses: github/codeql-action/analyze@v4.37.9
 
   trivy:
     name: Trivy filesystem scan
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Trivy results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.37.7
+        uses: github/codeql-action/upload-sarif@v4.37.9
         with:
           sarif_file: trivy-results.sarif
 
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload Trivy image results
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.37.7
+        uses: github/codeql-action/upload-sarif@v4.37.9
         with:
           sarif_file: trivy-${{ matrix.key }}.sarif
           category: trivy-image-${{ matrix.key }}


### PR DESCRIPTION
## Summary
- Bump `github/codeql-action` from 4.37.7 to 4.37.9 (Dependabot #231).
- Pin `aws-actions/configure-aws-credentials` from 6.2.3 to 6.2.4 (`cbe3b39`) in AWS remote tests, RC remote tests, and the LAN deploy-queue workflow (Dependabot #232 plus the workflow added after that PR opened).

## Test plan
- [x] `python -m unittest tests.unit.test_deploy_lan_queue_workflow tests.unit.test_aws_remote_workflow_secrets`
- [ ] CI - Ansible-Pihole Checks
- [ ] Security scanning (CodeQL)


Made with [Cursor](https://cursor.com)